### PR TITLE
Also call setMin and setMax on control as this can change after CControl::setTag was called

### DIFF
--- a/vstgui/plugin-bindings/vst3editor.cpp
+++ b/vstgui/plugin-bindings/vst3editor.cpp
@@ -275,7 +275,11 @@ protected:
 		VSTGUI_RANGE_BASED_FOR_LOOP(ControlList, controls, CControl*, c)
 			c->setMouseEnabled (mouseEnabled);
 			if (parameter)
+			{
 				c->setDefaultValue ((float)defaultValue);
+				c->setMin (minValue);
+				c->setMax (maxValue);
+			}
 			CTextLabel* label = dynamic_cast<CTextLabel*>(c);
 			if (label)
 			{


### PR DESCRIPTION
This is necessary when you change the tag of a control.