### PR TITLE
Fix crash situations on OSX when the VSTGUI app loses focus, then regains it by clicking on a scrollbar

### DIFF
--- a/vstgui/lib/controls/cscrollbar.cpp
+++ b/vstgui/lib/controls/cscrollbar.cpp
@@ -60,6 +60,11 @@ CScrollbar::CScrollbar (const CScrollbar& v)
 //-----------------------------------------------------------------------------
 CScrollbar::~CScrollbar ()
 {
+	if (timer)
+	{
+		timer->forget();
+		timer = 0;
+	}
 }
 
 //-----------------------------------------------------------------------------
@@ -232,6 +237,11 @@ CMouseEventResult CScrollbar::onMouseDown (CPoint &where, const CButtonState& bu
 	}
 	else if (scrollerArea.pointInside (where))
 	{
+		if (timer)
+		{
+			timer->forget();
+			timer = 0;
+		}
 		doStepping ();
 		timer = new CVSTGUITimer (this, 250);
 		timer->start ();


### PR DESCRIPTION
In some rare cases it was possible to create 2 timers for the same
scrollbar.