### PR TITLE
Fix crash on CNewFileSelector (macfileselector.mm) because of a missing retain.

### DIFF
--- a/vstgui/lib/platform/mac/macfileselector.mm
+++ b/vstgui/lib/platform/mac/macfileselector.mm
@@ -182,7 +182,7 @@ bool CocoaFileSelector::runInternal (CBaseObject* _delegate)
 				}
 			}
 			if (uti == 0 && (*it).getExtension ())
-				uti = [NSString stringWithUTF8String:(*it).getExtension ()];
+				uti = [[NSString stringWithUTF8String:(*it).getExtension ()] retain];
 			if (uti)
 			{
 				[typesArray addObject:uti];


### PR DESCRIPTION
While 10.11 wasn’t crashing, older systems (e.g. 10.9.5) were and
without the retain, "uti" would get released a few lines below, causing
a crash every time the Open or Save dialogs were used.