### PR TITLE
Clear NSPasteboard contents if dataSource is not valid.

### DIFF
--- a/vstgui/lib/platform/mac/macclipboard.mm
+++ b/vstgui/lib/platform/mac/macclipboard.mm
@@ -269,7 +269,7 @@ void setClipboard (IDataPackage* dataSource)
 	}
 	else
 	{
-		[pb declareTypes:[NSArray array] owner:nil];
+		[pb clearContents];
 	}
 }
 


### PR DESCRIPTION
The method is available since Mac OS X 10.6 and more precisely represents intention of the code.