### PR TITLE
Fix Cocoa check style COptionMenu which displayed check mark next to wrong menu item

### DIFF
--- a/vstgui/lib/platform/mac/cocoa/nsviewoptionmenu.mm
+++ b/vstgui/lib/platform/mac/cocoa/nsviewoptionmenu.mm
@@ -307,7 +307,7 @@ PlatformOptionMenuResult NSViewOptionMenu::popup (COptionMenu* optionMenu)
 		[item setTag:-1];
 	}
 	if (!multipleCheck && optionMenu->getStyle () & kCheckStyle)
-		[[nsMenu itemWithTag:(NSInteger)optionMenu->getValue ()] setState:NSOnState];
+		[[nsMenu itemWithTag:(NSInteger)optionMenu->getCurrentIndex (true)] setState:NSOnState];
 
 	NSView* cellContainer = [[NSView alloc] initWithFrame:cellFrameRect];
 	[view addSubview:cellContainer];


### PR DESCRIPTION
Use of getCurrentIndex() instead of getValue() is consistent with OS X Carbon and Windows.