### PR TITLE
FIXED build on Windows SDK 10.0.10586.0

### DIFF
--- a/vstgui/lib/platform/win32/win32frame.cpp
+++ b/vstgui/lib/platform/win32/win32frame.cpp
@@ -191,7 +191,7 @@ Win32Frame::Win32Frame (IPlatformFrameCallback* frame, const CRect& size, HWND p
 	{
 		// when WS_EX_COMPOSITED is set drawing does not work correctly. This seems like a bug in Direct2D wich happens with this hotfix
 	}
-	else if (getSystemVersion ().dwMajorVersion >= 6) // Vista and above
+	else if (IsWindowsVistaOrGreater()) // Vista and above
 		style |= WS_EX_COMPOSITED;
 	else
 		backBuffer = createOffscreenContext (size.getWidth (), size.getHeight ());

--- a/vstgui/lib/platform/win32/win32frame.h
+++ b/vstgui/lib/platform/win32/win32frame.h
@@ -40,6 +40,7 @@
 #if WINDOWS
 
 #include <windows.h>
+#include <VersionHelpers.h>
 
 namespace VSTGUI {
 

--- a/vstgui/lib/platform/win32/win32support.cpp
+++ b/vstgui/lib/platform/win32/win32support.cpp
@@ -55,19 +55,6 @@ namespace VSTGUI {
 
 HINSTANCE GetInstance () { return (HINSTANCE)hInstance; }
 
-const OSVERSIONINFOEX& getSystemVersion ()
-{
-	static OSVERSIONINFOEX gSystemVersion = {0};
-	static bool once = true;
-	if (once)
-	{
-		memset (&gSystemVersion, 0, sizeof (gSystemVersion));
-		gSystemVersion.dwOSVersionInfoSize = sizeof (gSystemVersion);
-		GetVersionEx ((OSVERSIONINFO *)&gSystemVersion);
-	}
-	return gSystemVersion;
-}
-
 //-----------------------------------------------------------------------------
 #if VSTGUI_DIRECT2D_SUPPORT
 typedef HRESULT (WINAPI *D2D1CreateFactoryProc) (D2D1_FACTORY_TYPE type, REFIID riid, CONST D2D1_FACTORY_OPTIONS *pFactoryOptions, void** factory);

--- a/vstgui/lib/platform/win32/win32support.h
+++ b/vstgui/lib/platform/win32/win32support.h
@@ -62,7 +62,6 @@ namespace VSTGUI {
 class CDrawContext;
 
 extern HINSTANCE GetInstance ();
-extern const OSVERSIONINFOEX& getSystemVersion ();
 extern ID2D1Factory* getD2DFactory ();
 extern void useD2D ();
 extern void unuseD2D ();

--- a/vstgui/lib/platform/win32/win32textedit.cpp
+++ b/vstgui/lib/platform/win32/win32textedit.cpp
@@ -82,7 +82,7 @@ Win32TextEdit::Win32TextEdit (HWND parent, IPlatformTextEditCallback* textEdit)
 	text = stringHelper;
 
 	DWORD wxStyle = 0;
-	if (getD2DFactory () == 0 && getSystemVersion ().dwMajorVersion >= 6) // Vista and above
+	if (getD2DFactory () == 0 && IsWindowsVistaOrGreater()) // Vista and above
 		wxStyle = WS_EX_COMPOSITED;
 	wstyle |= WS_CHILD | WS_VISIBLE | ES_AUTOHSCROLL;
 	platformControl = CreateWindowEx (wxStyle,

--- a/vstgui/lib/platform/win32/winfileselector.cpp
+++ b/vstgui/lib/platform/win32/winfileselector.cpp
@@ -158,7 +158,7 @@ CNewFileSelector* CNewFileSelector::create (CFrame* parent, Style style)
 		#endif
 		return 0;
 	}
-	if (getSystemVersion ().dwMajorVersion >= 6) // Vista
+	if (IsWindowsVistaOrGreater()) // Vista
 		return new VistaFileSelector (parent, style);
 	return new XPFileSelector (parent, style);
 }


### PR DESCRIPTION
GetVersionEx is disabled with standard build options in Windows 10 SDK. May break people's code because I removed getSystemVersion. I have only tested build of uidescription test.