### PR TITLE
FIXED Windows 10 SDK build.

### DIFF
--- a/vstgui/lib/platform/win32/win32frame.cpp
+++ b/vstgui/lib/platform/win32/win32frame.cpp
@@ -191,7 +191,7 @@ Win32Frame::Win32Frame (IPlatformFrameCallback* frame, const CRect& size, HWND p
 	{
 		// when WS_EX_COMPOSITED is set drawing does not work correctly. This seems like a bug in Direct2D wich happens with this hotfix
 	}
-	else if (getSystemVersion ().dwMajorVersion >= 6) // Vista and above
+	else if (IsWindowsVistaOrGreater()) // Vista and above
 		style |= WS_EX_COMPOSITED;
 	else
 		backBuffer = createOffscreenContext (size.getWidth (), size.getHeight ());

--- a/vstgui/lib/platform/win32/win32support.cpp
+++ b/vstgui/lib/platform/win32/win32support.cpp
@@ -55,6 +55,7 @@ namespace VSTGUI {
 
 HINSTANCE GetInstance () { return (HINSTANCE)hInstance; }
 
+#ifndef VERSIONHELPERAPI
 const OSVERSIONINFOEX& getSystemVersion ()
 {
 	static OSVERSIONINFOEX gSystemVersion = {0};
@@ -67,6 +68,10 @@ const OSVERSIONINFOEX& getSystemVersion ()
 	}
 	return gSystemVersion;
 }
+const bool IsWindowsVistaOrGreater() {
+	return (getSystemVersion().dwMajorVersion >= 6);
+}
+#endif
 
 //-----------------------------------------------------------------------------
 #if VSTGUI_DIRECT2D_SUPPORT

--- a/vstgui/lib/platform/win32/win32support.h
+++ b/vstgui/lib/platform/win32/win32support.h
@@ -42,6 +42,9 @@
 #include "../../cbitmap.h"
 
 #include <windows.h>
+#if defined (WINAPI_FAMILY_SYSTEM)
+#include <VersionHelpers.h>
+#endif
 
 #include <objidl.h>
 #include <gdiplus.h>
@@ -62,7 +65,10 @@ namespace VSTGUI {
 class CDrawContext;
 
 extern HINSTANCE GetInstance ();
-extern const OSVERSIONINFOEX& getSystemVersion ();
+#ifndef VERSIONHELPERAPI
+extern const OSVERSIONINFOEX& getSystemVersion();
+extern const bool IsWindowsVistaOrGreater();
+#endif
 extern ID2D1Factory* getD2DFactory ();
 extern void useD2D ();
 extern void unuseD2D ();

--- a/vstgui/lib/platform/win32/win32textedit.cpp
+++ b/vstgui/lib/platform/win32/win32textedit.cpp
@@ -82,7 +82,7 @@ Win32TextEdit::Win32TextEdit (HWND parent, IPlatformTextEditCallback* textEdit)
 	text = stringHelper;
 
 	DWORD wxStyle = 0;
-	if (getD2DFactory () == 0 && getSystemVersion ().dwMajorVersion >= 6) // Vista and above
+	if (getD2DFactory () == 0 && IsWindowsVistaOrGreater()) // Vista and above
 		wxStyle = WS_EX_COMPOSITED;
 	wstyle |= WS_CHILD | WS_VISIBLE | ES_AUTOHSCROLL;
 	platformControl = CreateWindowEx (wxStyle,

--- a/vstgui/lib/platform/win32/winfileselector.cpp
+++ b/vstgui/lib/platform/win32/winfileselector.cpp
@@ -158,7 +158,7 @@ CNewFileSelector* CNewFileSelector::create (CFrame* parent, Style style)
 		#endif
 		return 0;
 	}
-	if (getSystemVersion ().dwMajorVersion >= 6) // Vista
+	if (IsWindowsVistaOrGreater()) // Vista
 		return new VistaFileSelector (parent, style);
 	return new XPFileSelector (parent, style);
 }


### PR DESCRIPTION
WINAPI_FAMILY_SYSTEM is defined in Windows 10 SDK. For other SDKs behavior is like before.

Occurences of:
getSystemVersion ().dwMajorVersion >= 6
Need to be replaced with:
IsWindowsVistaOrGreater()

Tested with Windows SDK Versions 10.0.10586.0 and 8.1. Tested build of uidescription test_vs2015.