### PR TITLE
support for MinGW and cross compilation

### DIFF
--- a/vstgui/CMakeLists.txt
+++ b/vstgui/CMakeLists.txt
@@ -13,7 +13,7 @@ function(vstgui_set_cxx_version target version)
   set_property(TARGET ${target} PROPERTY CXX_STANDARD ${version})
   set_property(TARGET ${target} PROPERTY CXX_STANDARD_REQUIRED ON)
   set_property(TARGET ${target} PROPERTY CMAKE_CXX_STANDARD_REQUIRED ON)
-  if(APPLE)
+  if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   	target_compile_options(${target} PUBLIC "-stdlib=libc++")
   endif()
 endfunction(vstgui_set_cxx_version target version)
@@ -55,7 +55,7 @@ endif()
 ##########################################################################################
 set(VSTGUI_COMPILE_DEFINITIONS_DEBUG "VSTGUI_LIVE_EDITING;DEBUG")
 set(VSTGUI_COMPILE_DEFINITIONS_RELEASE "NDEBUG;RELEASE")
-if(CMAKE_HOST_APPLE)
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
 	if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 7)
 		set(VSTGUI_LTO_COMPILER_FLAGS "-O3 -flto=thin")
 	else()
@@ -63,7 +63,7 @@ if(CMAKE_HOST_APPLE)
 	endif()
   set(VSTGUI_LTO_LINKER_FLAGS "")
 endif()
-if(UNIX AND NOT CMAKE_HOST_APPLE)
+if(CMAKE_SYSTEM_NAME MATCHES "^(Linux|.*BSD)")
 	set(VSTGUI_LTO_COMPILER_FLAGS "-O3 -flto")
 	set(VSTGUI_LTO_LINKER_FLAGS "")
 	find_package(X11 REQUIRED)
@@ -110,6 +110,13 @@ set(CMAKE_STATIC_LINKER_FLAGS_RELEASELTO
   "${CMAKE_STATIC_LINKER_FLAGS_RELEASE} ${VSTGUI_LTO_LINKER_FLAGS}"
 )
 
+if(CMAKE_SYSTEM_NAME MATCHES "Windows" AND
+    (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+  add_definitions(-D_WIN32_WINNT=0x601 -DWINVER=0x601)
+  add_definitions(-DWIN32_LEAN_AND_MEAN=1)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-multichar")
+endif()
+
 ##########################################################################################
 if(NOT CMAKE_CONFIGURATION_TYPES)
   if(NOT CMAKE_BUILD_TYPE)
@@ -136,7 +143,11 @@ endif()
 add_subdirectory(lib)
 add_subdirectory(uidescription)
 
-if(UNIX AND NOT CMAKE_HOST_APPLE)
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+  set(VSTGUI_DISABLE_STANDALONE 1)
+endif()
+if(CMAKE_SYSTEM_NAME MATCHES "Windows" AND
+    (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
   set(VSTGUI_DISABLE_STANDALONE 1)
 endif()
 

--- a/vstgui/lib/CMakeLists.txt
+++ b/vstgui/lib/CMakeLists.txt
@@ -249,18 +249,18 @@ set(${target}_linux_sources
 )
 
 ##########################################################################################
-if(CMAKE_HOST_APPLE)
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   set(${target}_sources ${${target}_common_sources} ${${target}_mac_sources})
 endif()
 
 ##########################################################################################
-if(MSVC)
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
   set(${target}_sources ${${target}_common_sources} ${${target}_win32_sources})
 endif()
 
 ##########################################################################################
 # Linux
-if(UNIX AND NOT CMAKE_HOST_APPLE)
+if(CMAKE_SYSTEM_NAME MATCHES "^(Linux|.*BSD)")
 	set(${target}_sources ${${target}_common_sources} ${${target}_linux_sources})
 endif()
 
@@ -271,7 +271,7 @@ target_compile_definitions(${target} ${VSTGUI_COMPILE_DEFINITIONS})
 vstgui_set_cxx_version(${target} 11)
 vstgui_source_group_by_folder(${target})
 
-if(UNIX AND NOT CMAKE_HOST_APPLE)
+if(CMAKE_SYSTEM_NAME MATCHES "^(Linux|.*BSD)")
 	target_include_directories(${target} PRIVATE ${X11_INCLUDE_DIR})
     target_include_directories(${target} PRIVATE ${GTK3_INCLUDE_DIRS})
     target_include_directories(${target} PRIVATE ${GTKMM3_INCLUDE_DIRS})

--- a/vstgui/lib/platform/win32/win32dragcontainer.h
+++ b/vstgui/lib/platform/win32/win32dragcontainer.h
@@ -10,6 +10,7 @@
 #if WINDOWS
 
 #include <windows.h>
+#include <objidl.h>
 #include <vector>
 #include <string>
 

--- a/vstgui/standalone/CMakeLists.txt
+++ b/vstgui/standalone/CMakeLists.txt
@@ -74,7 +74,7 @@ set(${target}_win32_sources
 )
 
 ##########################################################################################
-if(CMAKE_HOST_APPLE)
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
 	set(${target}_sources ${${target}_common_sources} ${${target}_mac_sources})
 
 	set_source_files_properties(${${target}_sources} PROPERTIES
@@ -83,7 +83,7 @@ if(CMAKE_HOST_APPLE)
 endif()
 
 ##########################################################################################
-if(MSVC)
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
 	set(${target}_sources ${${target}_common_sources} ${${target}_win32_sources})
 endif()
 

--- a/vstgui/tests/unittest/CMakeLists.txt
+++ b/vstgui/tests/unittest/CMakeLists.txt
@@ -77,7 +77,7 @@ set(${target}_sources
 )
 
 ##########################################################################################
-if(CMAKE_HOST_APPLE)
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
 	set(${target}_sources
 		${${target}_sources}
 		"${VSTGUI_TEST_BASE}lib/platform_helper_mac.mm"
@@ -93,16 +93,22 @@ if(CMAKE_HOST_APPLE)
 endif()
 
 ##########################################################################################
-if(MSVC)
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
 	set(${target}_sources
 		${${target}_sources}
 		"${VSTGUI_TEST_BASE}lib/platform_helper_win32.cpp"
 		"${VSTGUI_TEST_BASE}../../vstgui_win32.cpp"
 	)
+	set(${target}_PLATFORM_LIBS
+		opengl32
+		gdiplus
+		shlwapi
+		windowscodecs
+	)
 endif()
 
 ##########################################################################################
-if(UNIX AND NOT CMAKE_HOST_APPLE)
+if(CMAKE_SYSTEM_NAME MATCHES "^(Linux|.*BSD)")
 	set(${target}_sources
 		${${target}_sources}
 		"${VSTGUI_TEST_BASE}lib/platform_helper_linux.cpp"
@@ -128,10 +134,12 @@ vstgui_set_cxx_version(${target} 14)
 target_compile_definitions(${target} ${VSTGUI_COMPILE_DEFINITIONS} ENABLE_UNIT_TESTS=1 VSTGUI_LIVE_EDITING=1)
 vstgui_source_group_by_folder(${target})
 
-add_custom_command(TARGET ${target} POST_BUILD COMMAND "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittests")
+if(NOT CMAKE_CROSSCOMPILING)
+	add_custom_command(TARGET ${target} POST_BUILD COMMAND "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittests")
+endif()
 
 ##########################################################################################
-if(UNIX AND NOT CMAKE_HOST_APPLE)
+if(CMAKE_SYSTEM_NAME MATCHES "^(Linux|.*BSD)")
 	target_include_directories(${target} PRIVATE ${X11_INCLUDE_DIR})
     target_include_directories(${target} PRIVATE ${GTK3_INCLUDE_DIRS})
     target_include_directories(${target} PRIVATE ${GTKMM3_INCLUDE_DIRS})

--- a/vstgui/tests/unittest/lib/platform_helper_win32.cpp
+++ b/vstgui/tests/unittest/lib/platform_helper_win32.cpp
@@ -4,7 +4,7 @@
 
 #include "platform_helper.h"
 #include "../../../lib/platform/win32/win32support.h"
-#include <Windows.h>
+#include <windows.h>
 
 namespace VSTGUI {
 namespace UnitTest {

--- a/vstgui/tests/unittest/unittests.cpp
+++ b/vstgui/tests/unittest/unittests.cpp
@@ -15,7 +15,8 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-#include <Windows.h>
+#include <windows.h>
+#include <objbase.h>
 #endif
 
 namespace VSTGUI {


### PR DESCRIPTION
This patch modifies the cmake build system with two objectives: to support compilation under MinGW and cross-compilation from a different OS.

The current build uses the variables of the host system instead of the target. Instead, I rely on cmake's system name. It is the reliable method used by the internal modules of cmake.
I detect MinGW when the compiler identifies as either gcc or clang, and in that case, I choose to disable the standalone version because the environment lacks the necessary headers.

I have also included some necessary source code modifications. Lowercase includes are needed for a case sensitive filesystem. I have defined WIN32_LEAN_AND_MEAN to prevent conflicts of type names between expat and the winapi, and I have added 2 inclusions made necessary by this change.