### PR TITLE
Avoid dereferencing a deleted CView in CViewContainer::removeAll

### DIFF
--- a/vstgui/lib/cviewcontainer.cpp
+++ b/vstgui/lib/cviewcontainer.cpp
@@ -443,7 +443,7 @@ bool CViewContainer::removeAll (bool withForget)
 	ViewList::iterator it = pImpl->children.begin ();
 	while (it != pImpl->children.end ())
 	{
-		CView* view = *it;
+		auto view = *it;
 		if (isAttached ())
 			view->removed (this);
 		pImpl->children.erase (it);


### PR DESCRIPTION
If there is a view in the children container with only one reference left, erasing it from the list will call its destructor. However, it will be deferenced in the following code.
The change postpones CView deletion up to the end of the while loop body.