### PR TITLE
Patch for win32 keyboard focus issues

### DIFF
--- a/vstgui/lib/platform/win32/win32frame.h
+++ b/vstgui/lib/platform/win32/win32frame.h
@@ -66,6 +66,7 @@ protected:
 	HWND parentWindow;
 	HWND windowHandle;
 	HWND tooltipWindow;
+	HWND oldFocusWindow;
 
 	COffscreenContext* backBuffer;
 	CDrawContext* deviceContext;


### PR DESCRIPTION
-Retrieve modifier keys asynchronously, so e.g. Pro Tools doesn't steal them away.
-Forward unprocessed key events to the previous focus window so we don't steal them away from e.g. Pro Tools.