### PR TITLE
Fixed drawing Win32OptionMenu checks in multiple check style.

### DIFF
--- a/vstgui/lib/platform/win32/win32optionmenu.cpp
+++ b/vstgui/lib/platform/win32/win32optionmenu.cpp
@@ -195,7 +195,7 @@ HMENU Win32OptionMenu::createMenu (COptionMenu* _menu, int32_t& offsetIdx)
 					flags |= MF_DISABLED;
 				if (multipleCheck && item->isChecked ())
 					flags |= MF_CHECKED;
-				if (_menu->getStyle () & kCheckStyle && inc == _menu->getCurrentIndex (true))
+				if (_menu->getStyle () & kCheckStyle && !multipleCheck && inc == _menu->getCurrentIndex (true))
 					flags |= MF_CHECKED;
 				if (!(flags & MF_CHECKED))
 					flags |= MF_UNCHECKED;


### PR DESCRIPTION
Option menus with multiple check style behave differently on Windows and Mac. On Mac it behaves as expected, but on Windows the current index is always checked. This behaviour is expected for the standard check style, but not for multiple check style. I have fixed this issue in win32optionmenu.cpp in the function Win32OptionMenu::createMenu().

It becomes clear when you look at the definition of the flag kMultipleCheckStyle, which is defined as the number 1025, which is 10000000001. This is a strange definition for a bit flag.

Another way to fix this is to redefine the flag kMultipleCheckStyle, such that it is a power of 2.