### PR TITLE
Add support for different bitmap scaling qualities (BitmapInterpolationQuality)

### DIFF
--- a/vstgui/lib/cdrawcontext.cpp
+++ b/vstgui/lib/cdrawcontext.cpp
@@ -11,12 +11,6 @@
 
 namespace VSTGUI {
 
-
-//-----------------------------------------------------------------------------
-
-CDrawContext::BitmapInterpolationQuality
-	CDrawContext::interpolationQuality = kQualityDefault;
-
 //-----------------------------------------------------------------------------
 CDrawContext::CDrawContextState::CDrawContextState (const CDrawContextState& state)
 {
@@ -114,6 +108,12 @@ void CDrawContext::restoreGlobalState ()
 		DebugPrint ("No saved global state in draw context !!!\n");
 		#endif
 	}
+}
+
+//-----------------------------------------------------------------------------
+void CDrawContext::setBitmapInterpolationQuality(CBitmapInterpolationQuality quality)
+{
+	currentState.bitmapQuality = quality;
 }
 
 //-----------------------------------------------------------------------------

--- a/vstgui/lib/cdrawcontext.cpp
+++ b/vstgui/lib/cdrawcontext.cpp
@@ -111,7 +111,7 @@ void CDrawContext::restoreGlobalState ()
 }
 
 //-----------------------------------------------------------------------------
-void CDrawContext::setBitmapInterpolationQuality(CBitmapInterpolationQuality quality)
+void CDrawContext::setBitmapInterpolationQuality(BitmapInterpolationQuality quality)
 {
 	currentState.bitmapQuality = quality;
 }

--- a/vstgui/lib/cdrawcontext.cpp
+++ b/vstgui/lib/cdrawcontext.cpp
@@ -11,6 +11,12 @@
 
 namespace VSTGUI {
 
+
+//-----------------------------------------------------------------------------
+
+CDrawContext::BitmapInterpolationQuality
+	CDrawContext::interpolationQuality = kQualityDefault;
+
 //-----------------------------------------------------------------------------
 CDrawContext::CDrawContextState::CDrawContextState (const CDrawContextState& state)
 {

--- a/vstgui/lib/cdrawcontext.h
+++ b/vstgui/lib/cdrawcontext.h
@@ -70,14 +70,16 @@ public:
 	// @name Bitmap Interpolation Quality
 	//-----------------------------------------------------------------------------
 	//@{
-	enum BitmapInterpolationQuality
+	enum CBitmapInterpolationQuality
 	{
-		kQualityDefault = 0,
-		kQualityLow,
-		kQualityHigh
+		kQualityDefault = 0,	// Let system decide
+		kQualityLow,			// Nearest neighbour
+		kQualityMedium,			// Bilinear interpolation
+		kQualityHigh			// Bicubic interpolation (Bilinear on Windows)
 	};
 
-	static BitmapInterpolationQuality interpolationQuality;
+	virtual void setBitmapInterpolationQuality (CBitmapInterpolationQuality quality);	//< set the current bitmap interpolation quality
+	const CBitmapInterpolationQuality& getBitmapInterpolationQuality () const { return currentState.bitmapQuality; }	///< get the current bitmap interpolation quality
 
 	//@}
 
@@ -224,6 +226,7 @@ protected:
 		CLineStyle lineStyle {kLineOnOffDash};
 		CDrawMode drawMode {kAntiAliasing};
 		float globalAlpha {1.f};
+		CBitmapInterpolationQuality bitmapQuality {kQualityDefault};
 
 		CDrawContextState () = default;
 		CDrawContextState (const CDrawContextState& state);

--- a/vstgui/lib/cdrawcontext.h
+++ b/vstgui/lib/cdrawcontext.h
@@ -67,6 +67,21 @@ public:
 	//@}
 
 	//-----------------------------------------------------------------------------
+	// @name Bitmap Interpolation Quality
+	//-----------------------------------------------------------------------------
+	//@{
+	enum BitmapInterpolationQuality
+	{
+		kQualityDefault = 0,
+		kQualityLow,
+		kQualityHigh
+	};
+
+	static BitmapInterpolationQuality interpolationQuality;
+
+	//@}
+
+	//-----------------------------------------------------------------------------
 	/// @name Line Mode
 	//-----------------------------------------------------------------------------
 	//@{

--- a/vstgui/lib/cdrawcontext.h
+++ b/vstgui/lib/cdrawcontext.h
@@ -218,7 +218,7 @@ protected:
 		CLineStyle lineStyle {kLineOnOffDash};
 		CDrawMode drawMode {kAntiAliasing};
 		float globalAlpha {1.f};
-		BitmapInterpolationQuality bitmapQuality {kQualityDefault};
+		BitmapInterpolationQuality bitmapQuality {BitmapInterpolationQuality::kDefault};
 
 		CDrawContextState () = default;
 		CDrawContextState (const CDrawContextState& state);

--- a/vstgui/lib/cdrawcontext.h
+++ b/vstgui/lib/cdrawcontext.h
@@ -70,16 +70,8 @@ public:
 	// @name Bitmap Interpolation Quality
 	//-----------------------------------------------------------------------------
 	//@{
-	enum CBitmapInterpolationQuality
-	{
-		kQualityDefault = 0,	// Let system decide
-		kQualityLow,			// Nearest neighbour
-		kQualityMedium,			// Bilinear interpolation
-		kQualityHigh			// Bicubic interpolation (Bilinear on Windows)
-	};
-
-	virtual void setBitmapInterpolationQuality (CBitmapInterpolationQuality quality);	//< set the current bitmap interpolation quality
-	const CBitmapInterpolationQuality& getBitmapInterpolationQuality () const { return currentState.bitmapQuality; }	///< get the current bitmap interpolation quality
+	virtual void setBitmapInterpolationQuality (BitmapInterpolationQuality quality);	///< set the current bitmap interpolation quality
+	const BitmapInterpolationQuality& getBitmapInterpolationQuality () const { return currentState.bitmapQuality; }	///< get the current bitmap interpolation quality
 
 	//@}
 
@@ -226,7 +218,7 @@ protected:
 		CLineStyle lineStyle {kLineOnOffDash};
 		CDrawMode drawMode {kAntiAliasing};
 		float globalAlpha {1.f};
-		CBitmapInterpolationQuality bitmapQuality {kQualityDefault};
+		BitmapInterpolationQuality bitmapQuality {kQualityDefault};
 
 		CDrawContextState () = default;
 		CDrawContextState (const CDrawContextState& state);

--- a/vstgui/lib/cframe.cpp
+++ b/vstgui/lib/cframe.cpp
@@ -72,7 +72,7 @@ struct CFrame::Impl
 	bool active {false};
 	bool windowActive {false};
 	bool inEventHandling {false};
-	BitmapInterpolationQuality bitmapQuality {kQualityDefault};
+	BitmapInterpolationQuality bitmapQuality {BitmapInterpolationQuality::kDefault};
 
 	struct PostEventHandler
 	{
@@ -271,7 +271,7 @@ BitmapInterpolationQuality CFrame::getBitmapInterpolationQuality () const
 {
 	if (pImpl)
 		return pImpl->bitmapQuality;
-	return kQualityDefault;
+	return BitmapInterpolationQuality::kDefault;
 }
 
 //-----------------------------------------------------------------------------

--- a/vstgui/lib/cframe.cpp
+++ b/vstgui/lib/cframe.cpp
@@ -72,6 +72,7 @@ struct CFrame::Impl
 	bool active {false};
 	bool windowActive {false};
 	bool inEventHandling {false};
+	BitmapInterpolationQuality bitmapQuality {kQualityDefault};
 
 	struct PostEventHandler
 	{
@@ -110,10 +111,7 @@ On Windows it's a WS_CHILD Window.
 
 */
 //-----------------------------------------------------------------------------
-CFrame::CFrame (const CRect& inSize, VSTGUIEditorInterface* inEditor)
-:
-CViewContainer (inSize),
-bitmapQuality (CDrawContext::kQualityDefault)
+CFrame::CFrame (const CRect& inSize, VSTGUIEditorInterface* inEditor) : CViewContainer (inSize)
 {
 	pImpl = new Impl;
 	pImpl->editor = inEditor;
@@ -259,19 +257,21 @@ double CFrame::getZoom () const
 }
 
 //-----------------------------------------------------------------------------
-void CFrame::setBitmapInterpolationQuality (CDrawContext::CBitmapInterpolationQuality quality)
+void CFrame::setBitmapInterpolationQuality (BitmapInterpolationQuality quality)
 {
-	if (quality != bitmapQuality)
+	if (pImpl && pImpl->bitmapQuality != quality)
 	{
-		bitmapQuality = quality;
+		pImpl->bitmapQuality = quality;
 		invalid ();
 	}
 }
 
 //-----------------------------------------------------------------------------
-CDrawContext::CBitmapInterpolationQuality CFrame::getBitmapInterpolationQuality () const
+BitmapInterpolationQuality CFrame::getBitmapInterpolationQuality () const
 {
-	return bitmapQuality;
+	if (pImpl)
+		return pImpl->bitmapQuality;
+	return kQualityDefault;
 }
 
 //-----------------------------------------------------------------------------
@@ -309,7 +309,8 @@ void CFrame::drawRect (CDrawContext* pContext, const CRect& updateRect)
 	if (pContext)
 		pContext->remember ();
 
-	pContext->setBitmapInterpolationQuality(bitmapQuality);
+	if (pImpl)
+		pContext->setBitmapInterpolationQuality(pImpl->bitmapQuality);
 
 	CRect oldClip;
 	pContext->getClipRect (oldClip);

--- a/vstgui/lib/cframe.cpp
+++ b/vstgui/lib/cframe.cpp
@@ -111,7 +111,9 @@ On Windows it's a WS_CHILD Window.
 */
 //-----------------------------------------------------------------------------
 CFrame::CFrame (const CRect& inSize, VSTGUIEditorInterface* inEditor)
-: CViewContainer (inSize)
+:
+CViewContainer (inSize),
+bitmapQuality (CDrawContext::kQualityDefault)
 {
 	pImpl = new Impl;
 	pImpl->editor = inEditor;
@@ -250,13 +252,29 @@ bool CFrame::setZoom (double zoomFactor)
 	return result;
 }
 
-//------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 double CFrame::getZoom () const
 {
 	return pImpl->userScaleFactor;
 }
 
-//------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+void CFrame::setBitmapInterpolationQuality (CDrawContext::CBitmapInterpolationQuality quality)
+{
+	if (quality != bitmapQuality)
+	{
+		bitmapQuality = quality;
+		invalid ();
+	}
+}
+
+//-----------------------------------------------------------------------------
+CDrawContext::CBitmapInterpolationQuality CFrame::getBitmapInterpolationQuality () const
+{
+	return bitmapQuality;
+}
+
+//-----------------------------------------------------------------------------
 double CFrame::getScaleFactor () const
 {
 	return pImpl->platformScaleFactor * pImpl->userScaleFactor;
@@ -290,6 +308,8 @@ void CFrame::drawRect (CDrawContext* pContext, const CRect& updateRect)
 
 	if (pContext)
 		pContext->remember ();
+
+	pContext->setBitmapInterpolationQuality(bitmapQuality);
 
 	CRect oldClip;
 	pContext->getClipRect (oldClip);

--- a/vstgui/lib/cframe.h
+++ b/vstgui/lib/cframe.h
@@ -7,6 +7,7 @@
 
 #include "vstguifwd.h"
 #include "cviewcontainer.h"
+#include "cdrawcontext.h"
 #include "platform/iplatformframecallback.h"
 
 namespace VSTGUI {
@@ -43,6 +44,9 @@ public:
 
 	bool setZoom (double zoomFactor);				///< set zoom factor
 	double getZoom () const;						///< get zoom factor
+
+	void setBitmapInterpolationQuality (CDrawContext::CBitmapInterpolationQuality quality);		///< set interpolation quality for bitmaps
+	CDrawContext::CBitmapInterpolationQuality getBitmapInterpolationQuality () const;			///< get interpolation quality for bitmaps
 
 	double getScaleFactor () const;
 
@@ -179,7 +183,8 @@ public:
 	//-------------------------------------------
 protected:
 	struct CollectInvalidRects;
-	
+	CDrawContext::CBitmapInterpolationQuality bitmapQuality;
+
 	~CFrame () noexcept override = default;
 	void beforeDelete () override;
 	

--- a/vstgui/lib/cframe.h
+++ b/vstgui/lib/cframe.h
@@ -7,7 +7,6 @@
 
 #include "vstguifwd.h"
 #include "cviewcontainer.h"
-#include "cdrawcontext.h"
 #include "platform/iplatformframecallback.h"
 
 namespace VSTGUI {
@@ -45,8 +44,8 @@ public:
 	bool setZoom (double zoomFactor);				///< set zoom factor
 	double getZoom () const;						///< get zoom factor
 
-	void setBitmapInterpolationQuality (CDrawContext::CBitmapInterpolationQuality quality);		///< set interpolation quality for bitmaps
-	CDrawContext::CBitmapInterpolationQuality getBitmapInterpolationQuality () const;			///< get interpolation quality for bitmaps
+	void setBitmapInterpolationQuality (BitmapInterpolationQuality quality);	///< set interpolation quality for bitmaps
+	BitmapInterpolationQuality getBitmapInterpolationQuality () const;			///< get interpolation quality for bitmaps
 
 	double getScaleFactor () const;
 
@@ -183,7 +182,6 @@ public:
 	//-------------------------------------------
 protected:
 	struct CollectInvalidRects;
-	CDrawContext::CBitmapInterpolationQuality bitmapQuality;
 
 	~CFrame () noexcept override = default;
 	void beforeDelete () override;

--- a/vstgui/lib/platform/mac/cgdrawcontext.cpp
+++ b/vstgui/lib/platform/mac/cgdrawcontext.cpp
@@ -693,17 +693,17 @@ void CGDrawContext::setCGDrawContextQuality (CGContextRef context)
 {
 	switch (currentState.bitmapQuality)
 	{
-		case kQualityLow:
+		case BitmapInterpolationQuality::kLow:
 			CGContextSetShouldAntialias (context, false);
 			CGContextSetInterpolationQuality (context, kCGInterpolationNone);
 			break;
 
-		case kQualityMedium:
+		case BitmapInterpolationQuality::kMedium:
 			CGContextSetShouldAntialias (context, true);
 			CGContextSetInterpolationQuality (context, kCGInterpolationMedium);
 			break;
 
-		case kQualityHigh:
+		case BitmapInterpolationQuality::kHigh:
 			CGContextSetShouldAntialias (context, true);
 			CGContextSetInterpolationQuality (context, kCGInterpolationHigh);
 			break;

--- a/vstgui/lib/platform/mac/cgdrawcontext.cpp
+++ b/vstgui/lib/platform/mac/cgdrawcontext.cpp
@@ -691,18 +691,23 @@ void CGDrawContext::drawCGImageRef (CGContextRef context, CGImageRef image, CGLa
 
 void CGDrawContext::setCGDrawContextQuality (CGContextRef context)
 {
-	switch (interpolationQuality)
+	switch (currentState.bitmapQuality)
 	{
 		case kQualityLow:
 			CGContextSetShouldAntialias (context, false);
 			CGContextSetInterpolationQuality (context, kCGInterpolationNone);
 			break;
-			
+
+		case kQualityMedium:
+			CGContextSetShouldAntialias (context, true);
+			CGContextSetInterpolationQuality (context, kCGInterpolationMedium);
+			break;
+
 		case kQualityHigh:
 			CGContextSetShouldAntialias (context, true);
 			CGContextSetInterpolationQuality (context, kCGInterpolationHigh);
 			break;
-			
+
 		default:
 			break;
 	}

--- a/vstgui/lib/platform/mac/cgdrawcontext.cpp
+++ b/vstgui/lib/platform/mac/cgdrawcontext.cpp
@@ -592,6 +592,8 @@ void CGDrawContext::fillRectWithBitmap (CBitmap* bitmap, const CRect& srcRect, c
 			r.size.width = CGImageGetWidth (image);
 			r.size.height = CGImageGetHeight (image);
 			
+			setCGDrawContextQuality (context);
+
 			CGContextDrawTiledImage (context, r, image);
 			
 			releaseCGContext (context);
@@ -641,6 +643,8 @@ void CGDrawContext::drawBitmap (CBitmap* bitmap, const CRect& inRect, const CPoi
 //-----------------------------------------------------------------------------
 void CGDrawContext::drawCGImageRef (CGContextRef context, CGImageRef image, CGLayerRef layer, double bitmapScaleFactor, const CRect& inRect, const CPoint& inOffset, float alpha, CBitmap* bitmap)
 {
+	setCGDrawContextQuality (context);
+	
 	CRect rect (inRect);
 	CPoint offset (inOffset);
 	
@@ -680,6 +684,27 @@ void CGDrawContext::drawCGImageRef (CGContextRef context, CGImageRef image, CGLa
 	else
 	{
 		CGContextDrawImage (context, dest, image);
+	}
+}
+
+//-----------------------------------------------------------------------------
+
+void CGDrawContext::setCGDrawContextQuality (CGContextRef context)
+{
+	switch (interpolationQuality)
+	{
+		case kQualityLow:
+			CGContextSetShouldAntialias (context, false);
+			CGContextSetInterpolationQuality (context, kCGInterpolationNone);
+			break;
+			
+		case kQualityHigh:
+			CGContextSetShouldAntialias (context, true);
+			CGContextSetInterpolationQuality (context, kCGInterpolationHigh);
+			break;
+			
+		default:
+			break;
 	}
 }
 

--- a/vstgui/lib/platform/mac/cgdrawcontext.h
+++ b/vstgui/lib/platform/mac/cgdrawcontext.h
@@ -78,6 +78,8 @@ protected:
 	void init () override;
 	void drawCGImageRef (CGContextRef context, CGImageRef image, CGLayerRef layer, double imageScaleFactor, const CRect& inRect, const CPoint& inOffset, float alpha, CBitmap* bitmap);
 
+	void setCGDrawContextQuality (CGContextRef context);
+
 	CGContextRef cgContext;
 
 	using BitmapDrawCountMap = std::map<CGBitmap*, int32_t>;

--- a/vstgui/lib/platform/win32/direct2d/d2ddrawcontext.cpp
+++ b/vstgui/lib/platform/win32/direct2d/d2ddrawcontext.cpp
@@ -428,12 +428,12 @@ void D2DDrawContext::drawBitmap (CBitmap* bitmap, const CRect& dest, const CPoin
 				D2D1_BITMAP_INTERPOLATION_MODE mode;
 				switch (currentState.bitmapQuality)
 				{
-					case kQualityLow:
+					case BitmapInterpolationQuality::kLow:
 						mode = D2D1_BITMAP_INTERPOLATION_MODE_NEAREST_NEIGHBOR;
 						break;
 
-					case kQualityMedium:
-					case kQualityHigh:
+					case BitmapInterpolationQuality::kMedium:
+					case BitmapInterpolationQuality::kHigh:
 					default:
 						mode = D2D1_BITMAP_INTERPOLATION_MODE_LINEAR;
 						break;

--- a/vstgui/lib/platform/win32/direct2d/d2ddrawcontext.cpp
+++ b/vstgui/lib/platform/win32/direct2d/d2ddrawcontext.cpp
@@ -426,12 +426,13 @@ void D2DDrawContext::drawBitmap (CBitmap* bitmap, const CRect& dest, const CPoin
 				source.setHeight (d2d1Bitmap->GetSize ().height);
 
 				D2D1_BITMAP_INTERPOLATION_MODE mode;
-				switch (interpolationQuality)
+				switch (currentState.bitmapQuality)
 				{
 					case kQualityLow:
 						mode = D2D1_BITMAP_INTERPOLATION_MODE_NEAREST_NEIGHBOR;
 						break;
 
+					case kQualityMedium:
 					case kQualityHigh:
 					default:
 						mode = D2D1_BITMAP_INTERPOLATION_MODE_LINEAR;

--- a/vstgui/lib/platform/win32/direct2d/d2ddrawcontext.cpp
+++ b/vstgui/lib/platform/win32/direct2d/d2ddrawcontext.cpp
@@ -425,8 +425,21 @@ void D2DDrawContext::drawBitmap (CBitmap* bitmap, const CRect& dest, const CPoin
 				source.setWidth (d2d1Bitmap->GetSize ().width);
 				source.setHeight (d2d1Bitmap->GetSize ().height);
 
+				D2D1_BITMAP_INTERPOLATION_MODE mode;
+				switch (interpolationQuality)
+				{
+					case kQualityLow:
+						mode = D2D1_BITMAP_INTERPOLATION_MODE_NEAREST_NEIGHBOR;
+						break;
+
+					case kQualityHigh:
+					default:
+						mode = D2D1_BITMAP_INTERPOLATION_MODE_LINEAR;
+						break;
+				}
+
 				D2D1_RECT_F sourceRect = makeD2DRect (source);
-				renderTarget->DrawBitmap (d2d1Bitmap, makeD2DRect (d), alpha * currentState.globalAlpha, D2D1_BITMAP_INTERPOLATION_MODE_LINEAR, &sourceRect);
+				renderTarget->DrawBitmap (d2d1Bitmap, makeD2DRect (d), alpha * currentState.globalAlpha, mode, &sourceRect);
 			}
 		}
 	}

--- a/vstgui/lib/vstguifwd.h
+++ b/vstgui/lib/vstguifwd.h
@@ -77,12 +77,12 @@ enum DragResult {
 //----------------------------
 // @brief Bitmap Interpolation
 //----------------------------
-enum BitmapInterpolationQuality
+enum class BitmapInterpolationQuality
 {
-	kQualityDefault = 0,	///< Let system decide
-	kQualityLow,			///< Nearest neighbour
-	kQualityMedium,			///< Bilinear interpolation
-	kQualityHigh			///< Bicubic interpolation (Bilinear on Windows)
+	kDefault = 0,	///< Let system decide
+	kLow,			///< Nearest neighbour
+	kMedium,		///< Bilinear interpolation
+	kHigh			///< Bicubic interpolation (Bilinear on Windows)
 };
 
 // simple structs

--- a/vstgui/lib/vstguifwd.h
+++ b/vstgui/lib/vstguifwd.h
@@ -74,6 +74,17 @@ enum DragResult {
 	kDragError = -1
 };
 
+//----------------------------
+// @brief Bitmap Interpolation
+//----------------------------
+enum BitmapInterpolationQuality
+{
+	kQualityDefault = 0,	///< Let system decide
+	kQualityLow,			///< Nearest neighbour
+	kQualityMedium,			///< Bilinear interpolation
+	kQualityHigh			///< Bicubic interpolation (Bilinear on Windows)
+};
+
 // simple structs
 struct CColor;
 struct CPoint;


### PR DESCRIPTION
The bitmap scaling quality can be set per CDrawContext instance using the CDrawContext::setBitmapInterpolationQuality() or globally per CFrame instance using CFrame::setBitmapInterpolationQuality(), which then delegates the setting to the respective draw context in CFrame::drawRect().

Currently, there are three modes: kQualityDefault, kQualityLow, kQualityMedium and kQualityHigh.

This feature is transparent, i.e. nothing will change from the current behavior unless you set anything != kQualityDefault.

NOTE: A Gdiplus back end implementation was skipped given that Gdiplus will deprecated soon. Linux support is missing due to the lack of a test setup. Since the older direct2d API which d2ddrawcontext is based on only offers two modes (nearest neighbour and bilinear), the kQualityMedium and kQualityHigh settings both map to the same mode on Windows.