### PR TITLE
fix plugguieditor warnings

### DIFF
--- a/vstgui/plugin-bindings/plugguieditor.cpp
+++ b/vstgui/plugin-bindings/plugguieditor.cpp
@@ -28,7 +28,7 @@ This is the same as the AEffGUIEditor class except that this one allows
 the VSTGUI lib to build without VST dependencies.
 */
 PluginGUIEditor::PluginGUIEditor (void *pEffect) 
-	: effect (pEffect), inIdleStuff (false)
+	: effect (pEffect)
 {
 	systemWindow = 0;
 	lLastTicks   = getTicks ();

--- a/vstgui/plugin-bindings/plugguieditor.h
+++ b/vstgui/plugin-bindings/plugguieditor.h
@@ -53,13 +53,6 @@ public :
 	virtual int32_t setKnobMode (int32_t val);
 	virtual int32_t getKnobMode () const { return knobMode; }
 
-	// get the CFrame object
-	#if USE_NAMESPACE
-	VSTGUI::CFrame *getFrame () { return frame; }
-	#else
-	CFrame *getFrame () { return frame; }
-	#endif
-
 	virtual void beginEdit (int32_t index) {}
 	virtual void endEdit (int32_t index) {}
 
@@ -72,7 +65,6 @@ protected:
 
 private:
 	uint32_t lLastTicks;
-	bool inIdleStuff;
 
 	static int32_t knobMode;
 };


### PR DESCRIPTION
Remove getFrame() function override - the same function is defined
as const in parent class VSTGUIEditorInterface.
This removes the last occurrence of USE_NAMESPACE macro in VSTGUI.
Remove unused private member inIdleStuff.