### PR TITLE
Inverse transform position before passing it on.

### DIFF
--- a/vstgui/lib/cframe.cpp
+++ b/vstgui/lib/cframe.cpp
@@ -705,7 +705,9 @@ bool CFrame::onWheel (const CPoint &where, const CMouseWheelAxis &axis, const fl
 {
 	if (auto modalView = getModalView ())
 	{
-		return modalView->onWheel (where, axis, distance, buttons);
+		CPoint where2 (where);
+		getTransform ().inverse ().transform (where2);
+		return modalView->onWheel (where2, axis, distance, buttons);
 	}
 
 	bool result = false;


### PR DESCRIPTION
Issue: The GenericOptionMenu does not accept any mouse wheel when the editor is scaled (scaleFactor != 1). Therefore it is impossible to scroll inside the menu.

Solution: Whenever the CFrame passes on a <tt>CPoint where</tt> to the modal view it is "inverse transformed" to <tt>where2</tt> beforehand. Examples are <tt>CFrame::onMouseMoved</tt>, <tt>CFrame::onMouseDown</tt>, <tt>CFrame::hitTestSubViews</tt> ...

Therefore I believe it must be done in <tt>CFrame::onWheel</tt> as well.