### PR TITLE
Open generic option menu at the right location and with the correct size when editor is scaled.

### DIFF
--- a/vstgui/lib/platform/common/genericoptionmenu.cpp
+++ b/vstgui/lib/platform/common/genericoptionmenu.cpp
@@ -466,9 +466,9 @@ CView* setupGenericOptionMenu (Proc clickCallback, CViewContainer* container,
 	{
 		viewRect.setWidth (maxWidth);
 	}
-	if (frame)
+	if (container)
 	{
-		auto frSize = frame->getViewSize ();
+		auto frSize = container->getViewSize();
 		frSize.inset (6, 6); // frame margin
 
 		if (frSize.bottom < viewRect.bottom)
@@ -549,11 +549,14 @@ struct GenericOptionMenu::Impl
 GenericOptionMenu::GenericOptionMenu (CFrame* frame, CButtonState initialButtons,
                                       GenericOptionMenuTheme theme)
 {
+	auto frameSize = frame->getViewSize ();
+	frame->getTransform().inverse().transform(frameSize);
+
 	impl = std::unique_ptr<Impl> (new Impl);
 	impl->frame = frame;
 	impl->initialButtons = initialButtons;
 	impl->theme = theme;
-	impl->container = new CLayeredViewContainer (impl->frame->getViewSize ());
+	impl->container = new CLayeredViewContainer (frameSize);
 	impl->container->setZIndex (100);
 	impl->container->setTransparency (true);
 	impl->container->registerViewMouseListener (this);
@@ -629,7 +632,10 @@ void GenericOptionMenu::popup (COptionMenu* optionMenu, const Callback& callback
 		self->removeModalView ({menu, index});
 	};
 
-	auto viewRect = optionMenu->translateToGlobal (optionMenu->getViewSize ());
+	auto viewRect = optionMenu->getViewSize ();
+	CPoint p;
+	optionMenu->localToFrame (p);
+	viewRect.offset (p);
 	auto where = viewRect.getCenter ();
 
 	GenericOptionMenuDetail::setupGenericOptionMenu (clickCallback, impl->container, optionMenu,


### PR DESCRIPTION
Issue: the generic option menu opens up with an offset to its actual location and the height is either too short or to long (depending on the scale factor).

(Possible) solution: The commit contains the stuff we (@scheffle and me) already did in the office. Furthermore I added two small changes I try to explain:

1.) I assume, when adding the (modal) container which is covering the whole frame, the container needs to have the **UN**scaled size of the frame. This is why it is "inverse transformed" first and then used to create the container.
https://github.com/rehans/vstgui/tree/master/vstgui/lib/platform/common/genericoptionmenu.cpp#L552-L559

2.) Later on when binding the size of the menu to the frame, better use the container (which has the size of the frame with scaleFactor == 1) for that instead of the frame. The frame might be scaled whereas the container is not. So you cannot use the frame here I assume.
https://github.com/rehans/vstgui/tree/master/vstgui/lib/platform/common/genericoptionmenu.cpp#L471

Well, maybe this commit is wrong. But probably it helps to hunt done the problem ;)
(Furthermore I did not check this with submenus.)
