### PR TITLE
Do not include fileresourceinputstream.cpp twice

### DIFF
--- a/vstgui/vstgui_linux.cpp
+++ b/vstgui/vstgui_linux.cpp
@@ -11,5 +11,3 @@
 #include "lib/platform/linux/cairofont.cpp"
 #include "lib/platform/linux/cairogradient.cpp"
 #include "lib/platform/linux/cairopath.cpp"
-
-#include "lib/platform/common/fileresourceinputstream.cpp"

--- a/vstgui/vstgui_mac.mm
+++ b/vstgui/vstgui_mac.mm
@@ -24,4 +24,3 @@
 #import "lib/platform/mac/cocoa/nsviewframe.mm"
 #import "lib/platform/mac/cocoa/nsviewoptionmenu.mm"
 #import "lib/platform/mac/cocoa/nsviewdraggingsession.mm"
-#import "lib/platform/common/fileresourceinputstream.cpp"


### PR DESCRIPTION
Since lib/platform/common/fileresourceinputstream.cpp is already being
included by vstgui.cpp, it does not need to be included by
vstgui_linux.cpp or vstgui_mac.mm.