### PR TITLE
fixes #93 (Capture set after popup menu item selected causes next mou…

### DIFF
--- a/vstgui/lib/platform/win32/win32frame.cpp
+++ b/vstgui/lib/platform/win32/win32frame.cpp
@@ -804,8 +804,13 @@ LONG_PTR WINAPI Win32Frame::proc (HWND hwnd, UINT message, WPARAM wParam, LPARAM
 
 			CPoint where (GET_X_LPARAM (lParam), GET_Y_LPARAM (lParam));
 			if (pFrame->platformOnMouseDown (where, buttons) == kMouseEventHandled && getPlatformWindow ())
-				SetCapture (getPlatformWindow ());
-			return 0;
+		CPoint where (GET_X_LPARAM (lParam), GET_Y_LPARAM (lParam));
+		if (pFrame->platformOnMouseDown (where, buttons) == kMouseEventHandled && getPlatformWindow ())
+    {//only set capture on mousedown if not left button or left button is still down. It is not after calling trackpopup menu
+         if ((buttons & kLButton) == 0 || GetAsyncKeyState (VK_LBUTTON) < 0)
+             SetCapture (getPlatformWindow ());
+    		}
+ 		return 0;
 		}
 		case WM_MOUSELEAVE:
 		{


### PR DESCRIPTION
…se click to be ignored)

@sagantech posted this code change but didn't make a PR. so here's me doing a PR for him.

conversation at
https://github.com/steinbergmedia/vstgui/issues/93

topic "Capture set after popup menu item selected causes next mouse click to be ignored"