### PR TITLE
Enable checkmarks on Parent Menus in Win32

### DIFF
--- a/vstgui/lib/platform/win32/win32optionmenu.cpp
+++ b/vstgui/lib/platform/win32/win32optionmenu.cpp
@@ -173,6 +173,10 @@ HMENU Win32OptionMenu::createMenu (COptionMenu* _menu, int32_t& offsetIdx)
 				HMENU submenu = createMenu (item->getSubmenu (), offsetIdx);
 				if (submenu)
 				{
+					if (multipleCheck && item->isChecked())
+					{
+						flags |= MF_CHECKED;
+					}
 					AppendMenu (menu, flags|MF_POPUP|MF_ENABLED, (UINT_PTR)submenu, (const TCHAR*)entryText);
 				}
 			}


### PR DESCRIPTION
Menu items with submenus beneath them dont accurately support
checkmarks on windows. This patch restores them. Thank you for considering this
patch!

Thanks to @sagantech who identified it.