### PR TITLE
Non-UTF8 Chars in Strings for Menus

### DIFF
--- a/vstgui/lib/platform/win32/win32support.h
+++ b/vstgui/lib/platform/win32/win32support.h
@@ -66,9 +66,9 @@ public:
 		{
 			if (!allocWideStr && utf8Str)
 			{
-				int numChars = MultiByteToWideChar (CP_UTF8, 0, utf8Str, numCharacters, 0, 0);
+				int numChars = MultiByteToWideChar (CP_ACP, 0, utf8Str, numCharacters, 0, 0);
 				allocWideStr = (WCHAR*)::std::malloc ((static_cast<size_t> (numChars)+1)*sizeof (WCHAR));
-				if (MultiByteToWideChar (CP_UTF8, 0, utf8Str, numCharacters, allocWideStr, numChars) == 0)
+				if (MultiByteToWideChar (CP_ACP, 0, utf8Str, numCharacters, allocWideStr, numChars) == 0)
 				{
 					allocWideStr[0] = 0;
 				}
@@ -86,9 +86,9 @@ public:
 		{
 			if (!allocUTF8Str && wideStr)
 			{
-				int allocSize = WideCharToMultiByte (CP_UTF8, 0, wideStr, numCharacters, 0, 0, 0, 0);
+				int allocSize = WideCharToMultiByte (CP_ACP, 0, wideStr, numCharacters, 0, 0, 0, 0);
 				allocUTF8Str = (char*)::std::malloc (static_cast<size_t> (allocSize)+1);
-				if (WideCharToMultiByte (CP_UTF8, 0, wideStr, numCharacters, allocUTF8Str, allocSize, 0, 0) == 0)
+				if (WideCharToMultiByte (CP_ACP, 0, wideStr, numCharacters, allocUTF8Str, allocSize, 0, 0) == 0)
 				{
 					allocUTF8Str[0] = 0;
 				}


### PR DESCRIPTION
As reported by @sagantech, the win32support force to UTF8 means
things like characters with diacriticals and so on in menus fail
to render on win32. This changes the conversion and subsequent
display so vstgui popups and other compoenents can display the
correct character.