### PR TITLE
Fix two transform errors

### DIFF
--- a/vstgui/lib/cframe.cpp
+++ b/vstgui/lib/cframe.cpp
@@ -1012,7 +1012,7 @@ bool CFrame::getCurrentMouseLocation (CPoint &where) const
 	{
 		if (pImpl->platformFrame->getCurrentMousePosition (where))
 		{
-			getTransform().transform (where);
+			getTransform().inverse().transform (where);
 			return true;
 		}
 	}

--- a/vstgui/lib/platform/common/genericoptionmenu.cpp
+++ b/vstgui/lib/platform/common/genericoptionmenu.cpp
@@ -468,6 +468,13 @@ CView* setupGenericOptionMenu (Proc clickCallback, CViewContainer* container,
 	}
 	if (frame)
 	{
+		/*
+		** Our calculations above have been in non-transformed space, so to do fit calculations, we
+		** need to transform our size by the frame zoom
+		*/
+		CPoint szx = viewRect.getSize();
+		frame->getTransform().transform(szx);
+		viewRect.setSize(szx);
 		auto frSize = frame->getViewSize ();
 		frSize.inset (6, 6); // frame margin
 
@@ -490,6 +497,14 @@ CView* setupGenericOptionMenu (Proc clickCallback, CViewContainer* container,
 		viewRect.bound (frSize);
 		if (maxWidth > viewRect.getWidth ())
 			dataSource->setMaxWidth (viewRect.getWidth ());
+
+		/*
+		** Our result is in non-transformed space; we need to bring it back
+		** into screen coordinate space by applying inverse transform once
+		** we have done fit and finish above in pixel space
+		*/
+		frame->getTransform().inverse().transform(viewRect);
+
 	}
 	viewRect.makeIntegral ();
 	viewRect.inset (-1, -1);


### PR DESCRIPTION
When Transform is set to scale the UI in VSTGUI I found two errors which need addressing

1. CFrame::getCurrentMousePosition does a transform, not an inverse
transform, unlike other mouse positions. Thus the position is in the incorrect coordinate space

2. genericoptionmenu does calculations of option menu size and position
in the wrong transform space - application space not pixel space - so needs a 
transform to- and transform from- at the appropriate times to render correctly 
when transformed on linux. Of course on mac and windows, where the native menus
are used, this is not an issue.

In Surge we had worked around the first problem by applying an inverse transform twice to all our calls to getCurrentMosuePosition, but problem 2 broke our linux implementation with zoom.

Thank you for your consideration of this patch. If you would like a test example to exercise it, I can share the appropriate code paths in surge on linux and macintosh so you can try with or without.