### PR TITLE
Enter in GenericMenu

### DIFF
--- a/vstgui/lib/platform/common/genericoptionmenu.cpp
+++ b/vstgui/lib/platform/common/genericoptionmenu.cpp
@@ -174,6 +174,13 @@ private:
 					clickCallback (menu, CDataBrowser::kNoSelection);
 					return 1;
 				}
+				case VKEY_RETURN:
+				case VKEY_ENTER:
+				{
+					if (clickCallback)
+						clickCallback (menu,browser->getSelectedRow ());
+					return 1;
+				}
 				case VKEY_LEFT:
 				{
 					if (parentDataSource)


### PR DESCRIPTION
GenericOptionMenu (only used in linux) didn't respond to enter
in either master or develop branch. This change makes enter and
return both send the click callback if the callback is registered,
making keyboard navigation of the menus rather nice.