### PR TITLE
Fix a build error in X11::Frame

### DIFF
--- a/vstgui/lib/platform/linux/x11frame.h
+++ b/vstgui/lib/platform/linux/x11frame.h
@@ -70,7 +70,7 @@ private:
 	PlatformType getPlatformType () const override;
 	void onFrameClosed () override {}
 	Optional<UTF8String> convertCurrentKeyEventToText () override;
-	bool setupGenericOptionMenu (bool use, GenericOptionMenuTheme* theme = nullptr) override { return false; }
+	bool setupGenericOptionMenu (bool use, GenericOptionMenuTheme* theme = nullptr) override;
 
 	uint32_t getX11WindowID () const override;
 


### PR DESCRIPTION
The method has two definitions in conflict, one being in the header and the other found in `x11frame.cpp`.