### PR TITLE
Fix rounding error when using a non-integer scale factor

### DIFF
--- a/vstgui/lib/cframe.cpp
+++ b/vstgui/lib/cframe.cpp
@@ -246,8 +246,8 @@ bool CFrame::setZoom (double zoomFactor)
 	CGraphicsTransform currentTransform = getTransform ();
 	CCoord origWidth = getWidth () / currentTransform.m11;
 	CCoord origHeight = getHeight () / currentTransform.m22;
-	CCoord newWidth = std::ceil (origWidth * zoomFactor);
-	CCoord newHeight = std::ceil (origHeight * zoomFactor);
+	CCoord newWidth = std::round (origWidth * zoomFactor);
+	CCoord newHeight = std::round (origHeight * zoomFactor);
 	setAutosizingEnabled (false);
 	setTransform (CGraphicsTransform ().scale (zoomFactor, zoomFactor));
 	if (!setSize (newWidth, newHeight))

--- a/vstgui/plugin-bindings/vst3editor.cpp
+++ b/vstgui/plugin-bindings/vst3editor.cpp
@@ -566,7 +566,8 @@ bool VST3Editor::requestResize (const CPoint& newSize)
 	CCoord width = newSize.x;
 	CCoord height = newSize.y;
 	double scaleFactor = getAbsScaleFactor ();
-	if (editingEnabled || (width >= minSize.x * scaleFactor && width <= maxSize.x * scaleFactor && height >= minSize.y * scaleFactor && height <= maxSize.y * scaleFactor))
+	if (editingEnabled || (width >= std::round (minSize.x * scaleFactor) && width <= std::round (maxSize.x * scaleFactor) 
+                        && height >= std::round (minSize.y * scaleFactor) && height <= std::round (maxSize.y * scaleFactor)))
 	{
 		Steinberg::ViewRect vr;
 		vr.right = static_cast<Steinberg::int32> (width);


### PR DESCRIPTION
This fixes an issue causing VST3 plug-ins on Windows to not respond correctly to non-integer scale factors (e.g. 175%) and therefore be scaled incorrectly in hosts.