### PR TITLE
Fix X11 bad resource path initialization

### DIFF
--- a/vstgui/lib/platform/linux/cairobitmap.cpp
+++ b/vstgui/lib/platform/linux/cairobitmap.cpp
@@ -9,6 +9,10 @@
 #include <memory>
 #include <vector>
 
+#if LINUX
+#include "x11platform.h"
+#endif
+
 //------------------------------------------------------------------------
 namespace VSTGUI {
 namespace Cairo {
@@ -128,15 +132,6 @@ private:
 } // CairoBitmapPrivate
 
 //-----------------------------------------------------------------------------
-Bitmap::GetResourcePathFunc Bitmap::getResourcePath = [] () { return std::string (); };
-
-//-----------------------------------------------------------------------------
-void Bitmap::setGetResourcePathFunc (GetResourcePathFunc&& func)
-{
-	getResourcePath = std::move (func);
-}
-
-//-----------------------------------------------------------------------------
 SharedPointer<Bitmap> Bitmap::create (UTF8StringPtr absolutePath)
 {
 	if (auto surface = Cairo::CairoBitmapPrivate::createImageFromPath (absolutePath))
@@ -246,11 +241,21 @@ double Bitmap::getScaleFactor () const
 }
 
 //-----------------------------------------------------------------------------
+
 PNGBitmapBuffer Bitmap::createMemoryPNGRepresentation () const
 {
 	Cairo::CairoBitmapPrivate::PNGMemoryWriter writer;
 	return writer.create (getSurface ());
 }
+
+#if LINUX
+std::string Bitmap::getResourcePath ()
+{
+	auto path = X11::Platform::getInstance ().getPath ();
+	path += "/Contents/Resources/";
+	return path;
+}
+#endif
 
 //-----------------------------------------------------------------------------
 namespace CairoBitmapPrivate {

--- a/vstgui/lib/platform/linux/cairobitmap.h
+++ b/vstgui/lib/platform/linux/cairobitmap.h
@@ -49,16 +49,13 @@ public:
 
 	void unlock () { locked = false; }
 
-	using GetResourcePathFunc = std::function<std::string ()>;
-	static void setGetResourcePathFunc (GetResourcePathFunc&& func);
-
 private:
 	double scaleFactor {1.0};
 	SurfaceHandle surface;
 	CPoint size;
 	bool locked {false};
 
-	static GetResourcePathFunc getResourcePath;
+	static std::string getResourcePath ();
 };
 
 //------------------------------------------------------------------------

--- a/vstgui/lib/platform/linux/cairofont.cpp
+++ b/vstgui/lib/platform/linux/cairofont.cpp
@@ -143,9 +143,10 @@ private:
 	{
 		FcInit ();
 		auto config = FcInitLoadConfigAndFonts ();
-		if (!X11::Frame::resourcePath.empty ())
+		const UTF8String& resourcePath = X11::Frame::getResourcePath ();
+		if (!resourcePath.empty ())
 		{
-			auto fontDir = X11::Frame::resourcePath + "Fonts/";
+			auto fontDir = resourcePath + "Fonts/";
 			FcConfigAppFontAddDir (config, reinterpret_cast<const FcChar8*> (fontDir.data ()));
 		}
 

--- a/vstgui/lib/platform/linux/x11frame.cpp
+++ b/vstgui/lib/platform/linux/x11frame.cpp
@@ -795,7 +795,20 @@ Frame::CreateIResourceInputStreamFunc Frame::createResourceInputStreamFunc =
 };
 
 //------------------------------------------------------------------------
-UTF8String Frame::resourcePath = Platform::getInstance ().getPath () + "/Contents/Resources/";
+const UTF8String& Frame::getResourcePath ()
+{
+	if (!userDefinedResourcePath.empty ())
+	{
+		return userDefinedResourcePath;
+	}
+	else
+	{
+		static UTF8String path = Platform::getInstance ().getPath () + "/Contents/Resources/";
+		return path;
+	}
+}
+
+UTF8String Frame::userDefinedResourcePath;
 
 //------------------------------------------------------------------------
 } // X11

--- a/vstgui/lib/platform/linux/x11frame.h
+++ b/vstgui/lib/platform/linux/x11frame.h
@@ -32,7 +32,9 @@ public:
 
 	static CreateIResourceInputStreamFunc createResourceInputStreamFunc;
 
-	static UTF8String resourcePath;
+	static const UTF8String& getResourcePath ();
+
+	static UTF8String userDefinedResourcePath;
 
 private:
 	bool getGlobalPosition (CPoint& pos) const override;

--- a/vstgui/lib/platform/linux/x11platform.cpp
+++ b/vstgui/lib/platform/linux/x11platform.cpp
@@ -118,18 +118,11 @@ Platform& Platform::getInstance ()
 Platform::Platform ()
 {
 	impl = std::unique_ptr<Impl> (new Impl);
-
-	Cairo::Bitmap::setGetResourcePathFunc ([this]() {
-		auto path = getPath ();
-		path += "/Contents/Resources/";
-		return path;
-	});
 }
 
 //------------------------------------------------------------------------
 Platform::~Platform ()
 {
-	Cairo::Bitmap::setGetResourcePathFunc ([]() { return std::string (); });
 }
 
 //------------------------------------------------------------------------

--- a/vstgui/standalone/source/platform/gdk/gdkapplication.cpp
+++ b/vstgui/standalone/source/platform/gdk/gdkapplication.cpp
@@ -104,7 +104,7 @@ bool Application::init (int argc, char* argv[])
 				path += desc.u.name;
 				return FileResourceInputStream::create (path);
 			};
-		VSTGUI::X11::Frame::resourcePath = execPath + "/Resources/";
+		VSTGUI::X11::Frame::userDefinedResourcePath = execPath + "/Resources/";
 
 		PlatformCallbacks callbacks;
 		callbacks.quit = [this] () { quit (); };


### PR DESCRIPTION
This is a patch which fixes #129
Recently I found a new configuration which exhibits the bug again, which allows me to retest the patch.

Regarding this comment:
> If the issue is, that you cannot load a CBitmap before the CFrame object is created, then your usage of VSTGUI is wrong. 

I verified that CBitmap was indeed created before CFrame was, and the problem happens regardless.

- Before patch
![vstgui-orig-1](https://user-images.githubusercontent.com/17614485/95661846-e26d0d00-0b32-11eb-88b6-dc77a714760c.png)
- After patch
![vstgui-fixed-1](https://user-images.githubusercontent.com/17614485/95661847-e39e3a00-0b32-11eb-845b-f49171288618.png)
