### PR TITLE
Create CColor from 32bit Integer

### DIFF
--- a/vstgui/lib/ccolor.cpp
+++ b/vstgui/lib/ccolor.cpp
@@ -314,4 +314,13 @@ UTF8String CColor::toString () const
 	return UTF8String (str.str ());
 }
 
+//-----------------------------------------------------------------------------
+void CColor::fromRGBA(uint32_t color)
+{
+	red = (color >> 24) & 0xFF;
+	green = (color >> 16) & 0xFF;
+	blue = (color >> 8) & 0xFF;
+	alpha = color & 0xFF;
+}
+	
 } // VSTGUI

--- a/vstgui/lib/ccolor.h
+++ b/vstgui/lib/ccolor.h
@@ -122,6 +122,8 @@ struct CColor
 	bool fromString (UTF8StringPtr str);
 	UTF8String toString () const;
 	static bool isColorRepresentation (UTF8StringPtr str);
+	
+	void fromRGBA(uint32_t color);
 
 	/** red component [0..255] */
 	uint8_t red {255};


### PR DESCRIPTION
Many drawing / web applications define RGBA colors are 32bit integers.  The changes make it easy to use those colors in VSTGUI. 