### PR TITLE
Round segmentIndex properly.

### DIFF
--- a/vstgui/lib/controls/csegmentbutton.cpp
+++ b/vstgui/lib/controls/csegmentbutton.cpp
@@ -517,7 +517,10 @@ uint32_t CSegmentButton::getSegmentIndex (float value) const
 {
 	if (value < 0.f || value > 1.f)
 		return kPushBack;
-	return static_cast<uint32_t> (static_cast<float> (segments.size () - 1) * value);
+
+	const auto segmentIndex = static_cast<float> (segments.size () - 1) * value;
+	const auto segmentIndexRounded = static_cast<uint32_t> (segmentIndex + 0.5f);
+	return segmentIndexRounded;
 }
 
 //-----------------------------------------------------------------------------

--- a/vstgui/tests/unittest/lib/controls/csegmentbutton_test.cpp
+++ b/vstgui/tests/unittest/lib/controls/csegmentbutton_test.cpp
@@ -302,6 +302,32 @@ TESTCASE(CSegmentButtonTest,
 
 		parent->removed (root);
 	);
+	
+	TEST(mouseDownEventWithManySegments,
+		// Create segment button with 32 segments and attach it
+		const auto numSegments = 32;
+		CRect r (0, 0, 20 * numSegments, 100);
+		auto b = new CSegmentButton (r);
+		b->setStyle (CSegmentButton::Style::kHorizontal);
+		for (auto i = 0; i < numSegments; ++i)
+			b->addSegment ({});
+		for (const auto& s : b->getSegments())
+			EXPECT (s.rect == CRect (0, 0, 0, 0));
+		auto root = owned (new CViewContainer (r));
+		auto parent = new CViewContainer (r);
+		root->addView (parent);
+		parent->addView (b);
+		parent->attached (root);
+
+		// Select the e.g. 20th segment
+		constexpr auto kSelectedSegment = 20;
+		CPoint p (0, 0);
+		p (20 * kSelectedSegment + 5, 0);
+		EXPECT (b->onMouseDown (p, kLButton) == kMouseDownEventHandledButDontNeedMovedOrUpEvents);
+		EXPECT (b->getSelectedSegment () == kSelectedSegment);
+
+		parent->removed (root);
+	);
 
 	TEST(focusPathSetting,
 		CSegmentButton b (CRect (0, 0, 10, 10));


### PR DESCRIPTION
When a segment button has e.g. 32 entries, it is not possible to click on some segments because of rounding errors. Therefore proper rounding is needed.