### PR TITLE
Return an empty string, when string list is empty

### DIFF
--- a/vstgui/tests/unittest/uidescription/uiattributes_test.cpp
+++ b/vstgui/tests/unittest/uidescription/uiattributes_test.cpp
@@ -191,6 +191,11 @@ TESTCASE(UIAttributesTest,
 		EXPECT(UIAttributes::stringToRect ("0, 12.5, 5, 8", r) && r == CRect (0, 12.5, 5, 8))
 	)
 
+	TEST(stringArrayToString_emptyStringArray,
+		const UIAttributes::StringArray strings;
+		const auto s = UIAttributes::stringArrayToString(strings);
+		EXPECT(s.empty())
+	)
 );
 
 } // VSTGUI

--- a/vstgui/uidescription/uiattributes.cpp
+++ b/vstgui/uidescription/uiattributes.cpp
@@ -196,6 +196,9 @@ bool UIAttributes::stringToRect (const std::string& str, CRect& r)
 //-----------------------------------------------------------------------------
 std::string UIAttributes::stringArrayToString (const StringArray& values)
 {
+	if (values.empty())
+		return {};
+
 	std::string value;
 	size_t numValues = values.size ();
 	for (size_t i = 0; i < numValues - 1; i++)


### PR DESCRIPTION
This fixes a crash, when leaving the segment-names (Segment Button) empty in the Live Editor.