### PR TITLE
fix wrong clip rect calculation on linux

### DIFF
--- a/vstgui/lib/platform/linux/cairocontext.cpp
+++ b/vstgui/lib/platform/linux/cairocontext.cpp
@@ -56,10 +56,7 @@ inline bool needPixelAlignment (CDrawMode mode)
 DrawBlock::DrawBlock (Context& context) : context (context)
 {
 	auto ct = context.getCurrentTransform ();
-	CRect clip;
-	context.getClipRect (clip);
-	ct.transform (clip);
-	clip.bound (context.getSurfaceRect ());
+	CRect clip = context.getCurrentStateClipRect ();
 	if (clip.isEmpty ())
 	{
 		clipIsEmpty = true;
@@ -122,6 +119,12 @@ void Context::init ()
 	if (surface)
 		cr.assign (cairo_create (surface));
 	super::init ();
+}
+
+//-----------------------------------------------------------------------------
+CRect Context::getCurrentStateClipRect () const
+{
+	return getCurrentState ().clipRect;
 }
 
 //-----------------------------------------------------------------------------

--- a/vstgui/lib/platform/linux/cairocontext.h
+++ b/vstgui/lib/platform/linux/cairocontext.h
@@ -58,6 +58,7 @@ public:
 	void beginDraw () override;
 	void endDraw () override;
 
+	CRect getCurrentStateClipRect () const;
 private:
 	void init () override;
 	void setSourceColor (CColor color);


### PR DESCRIPTION
The correctly transformed clip rect is already in the current state. Applying the current transform may add other transforms that were set after the clip was set.