### PR TITLE
Do not let newValue exceed 1.0 when adding up valueOffset multiple ti…

### DIFF
--- a/vstgui/lib/controls/csegmentbutton.cpp
+++ b/vstgui/lib/controls/csegmentbutton.cpp
@@ -349,6 +349,9 @@ CMouseEventResult CSegmentButton::onMouseDown (CPoint& where, const CButtonState
 				break; // out of for loop
 			}
 			newValue += valueOffset;
+
+			// Last segment can lead to newValue > 1.0
+			newValue = std::min(newValue, 1.f);
 		}
 	}
 	return kMouseDownEventHandledButDontNeedMovedOrUpEvents;

--- a/vstgui/tests/unittest/lib/controls/csegmentbutton_test.cpp
+++ b/vstgui/tests/unittest/lib/controls/csegmentbutton_test.cpp
@@ -329,6 +329,33 @@ TESTCASE(CSegmentButtonTest,
 		parent->removed (root);
 	);
 
+	TEST(mouseDownEventOnLastSegment,
+		// Create segment button with 31 segments and attach it.
+		// 31 segments causing rounding errors inside segment button.
+		const auto numSegments = 31;
+		CRect r(0, 0, 20 * numSegments, 100);
+		auto b = new CSegmentButton(r);
+		b->setStyle(CSegmentButton::Style::kHorizontal);
+		for (auto i = 0; i < numSegments; ++i)
+			b->addSegment({});
+		for (const auto& s : b->getSegments())
+			EXPECT(s.rect == CRect(0, 0, 0, 0));
+		auto root = owned(new CViewContainer(r));
+		auto parent = new CViewContainer(r);
+		root->addView(parent);
+		parent->addView(b);
+		parent->attached(root);
+
+		// Select the last segment
+		constexpr auto kSelectedSegment = numSegments - 1;
+		CPoint p(0, 0);
+		p(20 * kSelectedSegment + 5, 0);
+		EXPECT(b->onMouseDown(p, kLButton) == kMouseDownEventHandledButDontNeedMovedOrUpEvents);
+		EXPECT(b->getSelectedSegment() == kSelectedSegment);
+
+		parent->removed(root);
+	);
+
 	TEST(focusPathSetting,
 		CSegmentButton b (CRect (0, 0, 10, 10));
 		EXPECT (b.drawFocusOnTop () == false);


### PR DESCRIPTION
…mes.

While calculating 'valueOffset' there can be small precision/rounding errors which add up when calculating 'newValue' each iteration (newValue += valueOffset;). Then 'newValue' can become something like 1.0000345 in the last iteration (resp. last segment).

When 'newValue' exceeds 1.0, 'getSegmentIndex' returns 'kPushBack' (large number), which is not desired in this case.

This phenomenon does not occur always but it is reproducible when numSegments == 31 