### PR TITLE
fix cairo drawing error when another frame closes

### DIFF
--- a/vstgui/lib/platform/linux/x11frame.cpp
+++ b/vstgui/lib/platform/linux/x11frame.cpp
@@ -121,7 +121,6 @@ struct DrawHandler
 
 	~DrawHandler ()
 	{
-		cairo_device_finish (device);
 		cairo_device_destroy (device);
 	}
 


### PR DESCRIPTION
If you have two CFrames open (for example two instances of the same
plugin), and close one of them, the drawing in the other one starts to
fail, with "the target surface has been finished" messages. The fix is
simple: just remove the call to cairo_device_finish.
cairo_device_destroy will call cairo_device_finish when it has decreased
the refcount to zero.