### PR TITLE
make extra interface for view event listening

### DIFF
--- a/vstgui/lib/cview.h
+++ b/vstgui/lib/cview.h
@@ -398,7 +398,10 @@ public:
 	//@{
 	void registerViewListener (IViewListener* listener);
 	void unregisterViewListener (IViewListener* listener);
-	
+
+	void registerViewEventListener (IViewEventListener* listener);
+	void unregisterViewEventListener (IViewEventListener* listener);
+
 	VSTGUI_DEPRECATED_MSG(
 	void registerViewMouseListener (IViewMouseListener* listener);, "Use registerViewListener instead")
 	VSTGUI_DEPRECATED_MSG(

--- a/vstgui/lib/iviewlistener.h
+++ b/vstgui/lib/iviewlistener.h
@@ -26,9 +26,21 @@ public:
 	virtual void viewTookFocus (CView* view) = 0;
 	virtual void viewWillDelete (CView* view) = 0;
 	/** @ingroup new_in_4_11 */
-	virtual void viewOnEvent (CView* view, Event& event) = 0;
-	/** @ingroup new_in_4_11 */
 	virtual void viewOnMouseEnabled (CView* view, bool state) = 0;
+};
+
+//-----------------------------------------------------------------------------
+/** @brief View Event Listener Interface
+ *
+ *	@ingroup new_in_4_11
+ */
+//-----------------------------------------------------------------------------
+class IViewEventListener
+{
+public:
+	virtual ~IViewEventListener () noexcept = default;
+
+	virtual void viewOnEvent (CView* view, Event& event) = 0;
 };
 
 //-----------------------------------------------------------------------------
@@ -59,8 +71,14 @@ public:
 	void viewLostFocus (CView* view) override {}
 	void viewTookFocus (CView* view) override {}
 	void viewWillDelete (CView* view) override {}
-	void viewOnEvent (CView* view, Event& event) override {}
 	void viewOnMouseEnabled (CView* view, bool state) override {}
+};
+
+//------------------------------------------------------------------------
+class ViewEventListenerAdapter : public IViewEventListener
+{
+public:
+	void viewOnEvent (CView* view, Event& event) override {}
 };
 
 //-----------------------------------------------------------------------------
@@ -83,7 +101,7 @@ public:
  *	@ingroup new_in_4_7
  */
 //-----------------------------------------------------------------------------
-class [[deprecated("Use IViewListener instead")]] IViewMouseListener
+class [[deprecated ("Use IViewListener/IViewEventListener instead")]] IViewMouseListener
 {
 public:
 	virtual ~IViewMouseListener () noexcept = default;
@@ -104,13 +122,10 @@ public:
  *	@ingroup new_in_4_7
  */
 //-----------------------------------------------------------------------------
-class [[deprecated("Use ViewListenerAdapter instead")]] ViewMouseListenerAdapter
-: public IViewMouseListener
-{
-public:
-	CMouseEventResult viewOnMouseDown (CView* view, CPoint pos, CButtonState buttons) override
-	{
-		return kMouseEventNotImplemented;
+class [[deprecated (
+	"Use ViewListenerAdapter/ViewEventListenerAdapter instead")]] ViewMouseListenerAdapter
+: public IViewMouseListener {public: CMouseEventResult viewOnMouseDown (
+	  CView * view, CPoint pos, CButtonState buttons) override {return kMouseEventNotImplemented;
 	}
 	CMouseEventResult viewOnMouseUp (CView* view, CPoint pos, CButtonState buttons) override
 	{

--- a/vstgui/lib/platform/common/genericoptionmenu.cpp
+++ b/vstgui/lib/platform/common/genericoptionmenu.cpp
@@ -591,7 +591,7 @@ GenericOptionMenu::GenericOptionMenu (CFrame* frame, MouseEventButtonState initi
 	impl->container = new Impl::ContainerT (frameSize);
 	impl->container->setZIndex (100);
 	impl->container->setTransparency (true);
-	impl->container->registerViewListener (this);
+	impl->container->registerViewEventListener (this);
 	impl->modalViewSession = impl->frame->beginModalViewSession (impl->container);
 	impl->focusDrawingWasEnabled = impl->frame->focusDrawingEnabled ();
 	impl->frame->setFocusDrawingEnabled (false);
@@ -621,24 +621,24 @@ void GenericOptionMenu::removeModalView (PlatformOptionMenuResult result)
 
 		auto self = shared (this);
 		impl->container->addAnimation (
-		    "OptionMenuDone", new AlphaValueAnimation (0.f, true),
-		    new CubicBezierTimingFunction (
-		        CubicBezierTimingFunction::easyOut (impl->theme.menuAnimationTime)),
-		    [self, result] (CView*, const IdStringPtr, IAnimationTarget*) {
-			    if (!self->impl->container)
-				    return;
-			    auto callback = std::move (self->impl->callback);
-			    self->impl->callback = nullptr;
-			    self->impl->container->unregisterViewListener (self);
-			    if (self->impl->modalViewSession)
-			    {
+			"OptionMenuDone", new AlphaValueAnimation (0.f, true),
+			new CubicBezierTimingFunction (
+				CubicBezierTimingFunction::easyOut (impl->theme.menuAnimationTime)),
+			[self, result] (CView*, const IdStringPtr, IAnimationTarget*) {
+				if (!self->impl->container)
+					return;
+				auto callback = std::move (self->impl->callback);
+				self->impl->callback = nullptr;
+				self->impl->container->unregisterViewEventListener (self);
+				if (self->impl->modalViewSession)
+				{
 					self->impl->frame->endModalViewSession (*self->impl->modalViewSession);
 					self->impl->modalViewSession = {};
 				}
-			    callback (self->impl->menu, result);
-			    self->impl->frame->setFocusView (self->impl->menu);
-			    self->impl->container = nullptr;
-		    });
+				callback (self->impl->menu, result);
+				self->impl->frame->setFocusView (self->impl->menu);
+				self->impl->container = nullptr;
+			});
 	}
 }
 
@@ -713,7 +713,7 @@ void GenericOptionMenu::popup (COptionMenu* optionMenu, const Callback& callback
 
 	auto self = shared (this);
 	auto clickCallback = [self] (COptionMenu* menu, int32_t index) {
-		self->impl->container->unregisterViewListener (self);
+		self->impl->container->unregisterViewEventListener (self);
 		self->removeModalView ({menu, index});
 	};
 

--- a/vstgui/lib/platform/common/genericoptionmenu.h
+++ b/vstgui/lib/platform/common/genericoptionmenu.h
@@ -41,7 +41,9 @@ struct IGenericOptionMenuListener
 };
 
 //------------------------------------------------------------------------
-class GenericOptionMenu : public IPlatformOptionMenu, public ViewListenerAdapter
+class GenericOptionMenu
+: public IPlatformOptionMenu
+, public ViewEventListenerAdapter
 {
 public:
 	GenericOptionMenu (CFrame* frame, MouseEventButtonState initialButtons,

--- a/vstgui/lib/vstguifwd.h
+++ b/vstgui/lib/vstguifwd.h
@@ -142,6 +142,7 @@ using GradientColorStopMap = std::multimap<double, CColor>;
 
 // interfaces
 class IViewListener;
+class IViewEventListener;
 class IViewContainerListener;
 class IViewMouseListener;
 class IDataPackage;

--- a/vstgui/tests/unittest/lib/cview_test.cpp
+++ b/vstgui/tests/unittest/lib/cview_test.cpp
@@ -40,7 +40,6 @@ struct ViewListener : public IViewListener
 		view->unregisterViewListener (this);
 		willDeleteCalled = true;
 	}
-	void viewOnEvent (CView* view, Event& event) override {}
 	void viewOnMouseEnabled (CView* view, bool state) override {}
 
 	bool sizeChangedCalled {false};

--- a/vstgui/uidescription/editing/uieditcontroller.cpp
+++ b/vstgui/uidescription/editing/uieditcontroller.cpp
@@ -304,10 +304,12 @@ protected:
 };
 
 //----------------------------------------------------------------------------------------------------
-class UIZoomSettingController : public IController,
-                                public IContextMenuController2,
-                                public ViewListenerAdapter,
-                                public NonAtomicReferenceCounted
+class UIZoomSettingController
+: public IController
+, public IContextMenuController2
+, public ViewListenerAdapter
+, public ViewEventListenerAdapter
+, public NonAtomicReferenceCounted
 {
 public:
 	UIZoomSettingController (UIEditController* editController)
@@ -404,6 +406,7 @@ public:
 				zoomValueControl->setFrameWidth (-1);
 				zoomValueControl->setTooltipText ("Editor Zoom");
 				zoomValueControl->registerViewListener (this);
+				zoomValueControl->registerViewEventListener (this);
 				zoomValueControl->setStyle (zoomValueControl->getStyle () | CTextEdit::kDoubleClickStyle);
 			}
 		}
@@ -459,6 +462,7 @@ public:
 	{
 		vstgui_assert (view == zoomValueControl);
 		view->unregisterViewListener (this);
+		view->unregisterViewEventListener (this);
 		zoomValueControl = nullptr;
 	}
 


### PR DESCRIPTION
as view events are dispatched very often it is more efficient to decouple this from the generic view listener interface