### PR TITLE
Use execvpe to execute zenity and kdialog

### DIFF
--- a/vstgui/lib/platform/linux/x11fileselector.cpp
+++ b/vstgui/lib/platform/linux/x11fileselector.cpp
@@ -3,6 +3,7 @@
 // distribution and at http://github.com/steinbergmedia/vstgui/LICENSE
 
 #include "x11fileselector.h"
+#include "../../vstguibase.h"
 #include <unistd.h>
 #include <sys/wait.h>
 #include <sys/types.h>
@@ -18,13 +19,19 @@ extern "C" { extern char **environ; }
 namespace VSTGUI {
 namespace X11 {
 
+#if LINUX
+// Use execvpe on Linux to support also NixOS based distributions
+static constexpr auto kdialogpath = "kdialog";
+static constexpr auto zenitypath = "zenity";
+#else
 static constexpr auto kdialogpath = "/usr/bin/kdialog";
 static constexpr auto zenitypath = "/usr/bin/zenity";
+#endif
 
 //------------------------------------------------------------------------
 struct FileSelector : IPlatformFileSelector
 {
-	FileSelector (PlatformFileSelectorStyle style) : style (style) { identifiyExDialogType (); }
+	FileSelector (PlatformFileSelectorStyle style) : style (style) {}
 
 	~FileSelector () noexcept { closeProcess (); }
 
@@ -36,15 +43,12 @@ struct FileSelector : IPlatformFileSelector
 
 	bool runDialog (const PlatformFileSelectorConfig& config)
 	{
-		switch (exDialogType)
-		{
-			case ExDialogType::kdialog:
-				return runKDialog (config);
-			case ExDialogType::zenity:
-				return runZenity (config);
-			case ExDialogType::none:
-				break;
-		}
+		if (runZenity (config))
+			return true;
+
+		if (runKDialog (config))
+			return true;
+
 		return false;
 	}
 
@@ -88,14 +92,6 @@ private:
 		kdialog,
 		zenity
 	};
-
-	void identifiyExDialogType ()
-	{
-		if (access (zenitypath, X_OK) != -1)
-			exDialogType = ExDialogType::zenity;
-		if (access (kdialogpath, X_OK) != -1)
-			exDialogType = ExDialogType::kdialog;
-	}
 
 	bool runKDialog (const PlatformFileSelectorConfig& config)
 	{
@@ -199,7 +195,9 @@ private:
 			return false;
 
 		if (forkPid == 0) {
-			execute (argv, envp, rw.fd);
+			if (!execute (argv, envp, rw.fd))
+				return false;
+
 			assert (false);
 		}
 
@@ -213,15 +211,21 @@ private:
 		return true;
 	}
 
-	[[noreturn]]
-	static void execute (char* argv[], char* envp[], const int pipeFd[2])
+	static bool execute (char* argv[], char* envp[], const int pipeFd[2])
 	{
 		close (pipeFd[0]);
 		if (dup2 (pipeFd[1], STDOUT_FILENO) == -1)
 			_exit (1);
 		close (pipeFd[1]);
-		execve (argv[0], argv, envp);
+#if LINUX
+		if (execvpe (argv[0], argv, envp) == -1)
+#else
+		if (execve (argv[0], argv, envp) == -1)
+#endif
+			return false;
+
 		_exit (1);
+		return true; // not reachable
 	}
 
 	void closeProcess ()


### PR DESCRIPTION
This removes the hard-coding of zenity or kdialog paths. Zenity is preferred still.