### PR TITLE
Add cassert include

### DIFF
--- a/vstgui/tests/unittest/lib/cviewcontainer_test.cpp
+++ b/vstgui/tests/unittest/lib/cviewcontainer_test.cpp
@@ -10,6 +10,7 @@
 #include "../unittests.h"
 #include "eventhelpers.h"
 #include <vector>
+#include <cassert>
 
 namespace VSTGUI {
 


### PR DESCRIPTION
On Windows, without the cassert include, you get: "cviewcontainer_test.cpp(112,1): error C3861: 'assert': identifier not found"