### PR TITLE
Add missing source to vstgui_linux.cpp

### DIFF
--- a/vstgui/vstgui_linux.cpp
+++ b/vstgui/vstgui_linux.cpp
@@ -2,6 +2,7 @@
 
 #include "lib/platform/linux/linuxstring.cpp"
 
+#include "lib/platform/linux/x11dragging.cpp"
 #include "lib/platform/linux/x11fileselector.cpp"
 #include "lib/platform/linux/x11frame.cpp"
 #include "lib/platform/linux/x11platform.cpp"


### PR DESCRIPTION
This lacks a source file, making the unity build fail on Linux platform.