### PR TITLE
Update macfactory.h

### DIFF
--- a/vstgui/lib/platform/mac/macfactory.h
+++ b/vstgui/lib/platform/mac/macfactory.h
@@ -134,7 +134,7 @@ public:
 	 *	@return platform file selector or nullptr on failure
 	 */
 	PlatformFileSelectorPtr createFileSelector (PlatformFileSelectorStyle style,
-												IPlatformFrame* frame) const noexcept;
+												IPlatformFrame* frame) const noexcept override;
 
 	const LinuxFactory* asLinuxFactory () const noexcept final;
 	const MacFactory* asMacFactory () const noexcept final;

--- a/vstgui/lib/platform/mac/macfactory.h
+++ b/vstgui/lib/platform/mac/macfactory.h
@@ -134,7 +134,7 @@ public:
 	 *	@return platform file selector or nullptr on failure
 	 */
 	PlatformFileSelectorPtr createFileSelector (PlatformFileSelectorStyle style,
-												IPlatformFrame* frame) const noexcept override;
+												IPlatformFrame* frame) const noexcept final;
 
 	const LinuxFactory* asLinuxFactory () const noexcept final;
 	const MacFactory* asMacFactory () const noexcept final;


### PR DESCRIPTION
createFileSelector() overrides a member function but is missing the override keyword which leads to a compiler error on macOS Monterey on ARM64