### PR TITLE
fix close/reopen crash on linux. Fixes #249.

### DIFF
--- a/vstgui/lib/platform/linux/x11frame.cpp
+++ b/vstgui/lib/platform/linux/x11frame.cpp
@@ -177,6 +177,7 @@ struct DrawHandler
 
 	~DrawHandler ()
 	{
+		RunLoop::instance ().setDevice (device);
 		cairo_device_destroy (device);
 	}
 

--- a/vstgui/lib/platform/linux/x11frame.cpp
+++ b/vstgui/lib/platform/linux/x11frame.cpp
@@ -172,13 +172,7 @@ struct DrawHandler
 										   window.getSize ().x, window.getSize ().y);
 		windowSurface.assign (s);
 		onSizeChanged (window.getSize ());
-		device = cairo_device_reference (cairo_surface_get_device (s));
-	}
-
-	~DrawHandler ()
-	{
-		RunLoop::instance ().setDevice (device);
-		cairo_device_destroy (device);
+		RunLoop::instance ().setDevice (cairo_surface_get_device (s));
 	}
 
 	void onSizeChanged (const CPoint& size)
@@ -213,7 +207,6 @@ struct DrawHandler
 	}
 
 private:
-	cairo_device_t* device = nullptr;
 	Cairo::SurfaceHandle windowSurface;
 	Cairo::SurfaceHandle backBuffer;
 	SharedPointer<Cairo::Context> drawContext;

--- a/vstgui/lib/platform/linux/x11platform.cpp
+++ b/vstgui/lib/platform/linux/x11platform.cpp
@@ -122,6 +122,7 @@ struct RunLoop::Impl : IEventHandler
 	std::array<xcb_cursor_t, CCursorType::kCursorIBeam + 1> cursors {{XCB_CURSOR_NONE}};
 	KeyboardEvent lastUnprocessedKeyEvent;
 	uint32_t lastUtf32KeyEventChar {0};
+	cairo_device_t* device {nullptr};
 
 	void init (const SharedPointer<IRunLoop>& inRunLoop)
 	{
@@ -166,6 +167,11 @@ struct RunLoop::Impl : IEventHandler
 	{
 		if (--useCount != 0)
 			return;
+
+		cairo_device_finish (device);
+		cairo_device_destroy (device);
+		device = nullptr;
+
 		if (xcbConnection)
 		{
 			if (xkbUnprocessedState)
@@ -548,6 +554,15 @@ Optional<UTF8String> RunLoop::convertCurrentKeyEventToText () const
 	{
 	}
 	return {};
+}
+
+void RunLoop::setDevice (cairo_device_t* device)
+{
+	if (impl->device != device)
+	{
+		cairo_device_destroy (impl->device);
+		impl->device = cairo_device_reference (device);
+	}
 }
 
 //------------------------------------------------------------------------

--- a/vstgui/lib/platform/linux/x11platform.h
+++ b/vstgui/lib/platform/linux/x11platform.h
@@ -8,6 +8,7 @@
 #include "x11frame.h"
 #include <atomic>
 #include <memory>
+#include <cairo/cairo.h>
 
 struct xcb_connection_t;	  // forward declaration
 struct xcb_key_press_event_t; // forward declaration
@@ -62,6 +63,7 @@ struct RunLoop
 	KeyboardEvent&& getCurrentKeyEvent () const;
 	Optional<UTF8String> convertCurrentKeyEventToText () const;
 
+	void setDevice (cairo_device_t* device);
 	static RunLoop& instance ();
 
 private:


### PR DESCRIPTION
cairo_device_finish must be called before closing the xcb connection,
otherwise the invalid connection will not be removed from an internal
cairo cache. When reopening the editor there's then a risk that the
new connection has the same pointer value as the old one and that will
cause a crash.

The call to cairo_device_finish should not be made until the last
instance of the editor has been closed. If it's done earlier, the
remaining editors will stop working.