### PR TITLE
Fix build error on missing cstdint types.

### DIFF
--- a/vstgui/lib/algorithm.h
+++ b/vstgui/lib/algorithm.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "optional.h"
+#include <cstdint>
 #include <algorithm>
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
While building VST3SDK, I got this error on VSTGUI:

```
[ 60%] Building CXX object VSTGUI.build/standalone/CMakeFiles/vstgui_standalone.dir/source/uidescriptionwindowcontroller.cpp.o
In file included from /home/carlo/packages/vst3sdk/vst3sdk/vstgui4/vstgui/standalone/source/uidescriptionwindowcontroller.cpp:5:
/home/carlo/packages/vst3sdk/vst3sdk/vstgui4/vstgui/standalone/source/../../lib/algorithm.h:15:63: error: ‘int32_t’ does not name a type
   15 | template <typename Iter, typename Type, typename ResultType = int32_t>
      |                                                               ^~~~~~~
/home/carlo/packages/vst3sdk/vst3sdk/vstgui4/vstgui/standalone/source/../../lib/algorithm.h:9:1: note: ‘int32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
    8 | #include <algorithm>
  +++ |+#include <cstdint>
    9 |
```

The easy correction suggested by GCC fixed the error.
I think that this fix is also a good programming pratice, by not assuming that something is included by someone else, so I hope that it could be accepted.