### PR TITLE
Remove substraction of minValue.

### DIFF
--- a/vstgui/plugin-bindings/vst3editor.cpp
+++ b/vstgui/plugin-bindings/vst3editor.cpp
@@ -334,7 +334,7 @@ protected:
 							segment.name = getParamStringByIndex (i).text8 ();
 							segmentButton->addSegment (std::move (segment));
 						}
-						c->setValue ((float)value - minValue);
+						c->setValue ((float)value);
 					}
 					else
 					{


### PR DESCRIPTION
No need to subtract 'minValue' in this case. All transforms of value from physical to normalized and vice versa is handled correctly by CControl already. When 'minValue' > 0 it even breaks the segment button. 