### PR TITLE
Fix build warning in mactimer.cpp

### DIFF
--- a/vstgui/lib/platform/mac/mactimer.cpp
+++ b/vstgui/lib/platform/mac/mactimer.cpp
@@ -32,7 +32,7 @@ bool MacTimer::start (uint32_t fireTime)
 	if (timer)
 	{
 #if MAC_OS_X_VERSION_MAX_ALLOWED > MAC_OS_X_VERSION_10_8
-	#if MAC_OS_X_VERSION_MIN_REQUIRED <= MAX_OS_X_VERSION_10_8
+	#if MAC_OS_X_VERSION_MIN_REQUIRED <= MAC_OS_X_VERSION_10_8
 		if (CFRunLoopTimerSetTolerance)
 	#endif
 			CFRunLoopTimerSetTolerance (timer, fireTime * 0.0001f);


### PR DESCRIPTION
`MAX_OS_X_VERSION_10_8` is not a macro defined by Apple's headers; it should be `MAC_OS_X_VERSION_10_8`.

It's a good idea to use the [`-Wundef`](https://clang.llvm.org/docs/DiagnosticsReference.html#wundef) compiler flag to catch these kinds of issues.