### PR TITLE
Secure calling isVisible ()

### DIFF
--- a/vstgui/lib/cview.cpp
+++ b/vstgui/lib/cview.cpp
@@ -338,7 +338,7 @@ CGraphicsPath* CView::getHitTestPath () const
 //-----------------------------------------------------------------------------
 bool CView::hasViewFlag (int32_t bit) const
 {
-	return hasBit (pImpl->viewFlags, bit);
+	return pImpl && hasBit (pImpl->viewFlags, bit);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Proposing to check if pImpl is not destroyed. As otherwise, an implementation may call isVisible () on a CView that is already closed due to a race condition.