### PR TITLE
Notify callback or delegate when VistaFileSelector is canceled

### DIFF
--- a/vstgui/lib/platform/win32/winfileselector.cpp
+++ b/vstgui/lib/platform/win32/winfileselector.cpp
@@ -249,9 +249,9 @@ bool VistaFileSelector::run (const PlatformFileSelectorConfig& config)
 		}
 	}
 	hr = fileDialog->Show (parent);
+    std::vector<UTF8String> result;
 	if (SUCCEEDED (hr))
 	{
-		std::vector<UTF8String> result;
 		if (hasBit (config.flags, PlatformFileSelectorFlags::MultiFileSelection))
 		{
 			IFileOpenDialog* openFileDialog = nullptr;
@@ -301,9 +301,9 @@ bool VistaFileSelector::run (const PlatformFileSelectorConfig& config)
 				item->Release ();
 			}
 		}
-		if (config.doneCallback)
-			config.doneCallback (std::move (result));
 	}
+    if (config.doneCallback)
+        config.doneCallback (std::move (result));
 	fileDialog->Release ();
 	fileDialog = nullptr;
 	freeExtensionFilter (filters);


### PR DESCRIPTION
Unlike the macOS implementation, `CNewFileSelector` on Windows does not invoke the `CallbackFunc` or emit the `kSelectEndMessage` notification if the user cancels the file selector.

This seems to be a bug based on the existence of a [commit that fixed it in an earlier version of the implementation](https://github.com/steinbergmedia/vstgui/commit/7cdf23962f513ead054cfdd4b00c0df923ebd779).

This pull requests ensures that the `doneCallback` is executed on all code paths, so that clients of `CNewFileSelector` can reliably perform any necessary clean-up.