### PR TITLE
Fix leak in CNewFileSelector::run (CallbackFunc&& callback)

### DIFF
--- a/vstgui/lib/cfileselector.cpp
+++ b/vstgui/lib/cfileselector.cpp
@@ -189,10 +189,12 @@ bool CNewFileSelector::run (CallbackFunc&& callback)
 	if (impl->frame)
 		impl->frame->onStartLocalEventLoop ();
 
-	impl->doneCallback = [Self = shared (this),
+    remember ();
+	impl->doneCallback = [this,
 						  cb = std::move (callback)] (std::vector<UTF8String>&& files) {
-		Self->impl->result = std::move (files);
-		cb (Self);
+		impl->result = std::move (files);
+		cb (this);
+        forget ();
 	};
 
 	setBit (impl->flags, PlatformFileSelectorFlags::RunModal, false);


### PR DESCRIPTION
`CNewFileSelector` objects were being leaked when using `run (CallbackFunc&&)` because of a retain cycle; the lambda assigned to `impl->doneCallback` added a `SharedPointer` to `this` that would never be freed.

Verified by adding a breakpoint on `CNewFileSelector::~CNewFileSelector()`