### PR TITLE
fix 1 bug and disable clip for DrawBitmap

### DIFF
--- a/vstgui/lib/platform/win32/direct2d/d2dbitmap.cpp
+++ b/vstgui/lib/platform/win32/direct2d/d2dbitmap.cpp
@@ -233,7 +233,7 @@ HBITMAP D2DBitmap::createHBitmap ()
 	pbmi.bmiHeader.biPlanes = 1;
 	pbmi.bmiHeader.biCompression = BI_RGB;
 	pbmi.bmiHeader.biWidth = (LONG)size.x;
-	pbmi.bmiHeader.biHeight = (LONG)size.y;
+	pbmi.bmiHeader.biHeight = -(LONG)size.y;
 	pbmi.bmiHeader.biBitCount = 32;
 
 	HDC hdc = GetDC (nullptr);

--- a/vstgui/lib/platform/win32/direct2d/d2ddrawcontext.cpp
+++ b/vstgui/lib/platform/win32/direct2d/d2ddrawcontext.cpp
@@ -431,7 +431,7 @@ void D2DDrawContext::drawBitmap (CBitmap* bitmap, const CRect& dest, const CPoin
 {
 	if (renderTarget == nullptr)
 		return;
-	ConcatClip concatClip (*this, dest);
+	//ConcatClip concatClip (*this, dest);
 	D2DApplyClip ac (this);
 	if (ac.isEmpty ())
 		return;


### PR DESCRIPTION
D2DBitmap::createHBitmap need add minus to biHeight, otherwise we would get a vertical mirror icon.
D2DDrawContext::drawBitmap, we disabled the auto clip mode. If enable the auto clip, we will get a wrong clipped image when a transform matrix such as a rotate matrix was set.

