### PR TITLE
fix a bug that D2DBitmap::createHBitmap from CBitmap got a vertical mirror

### DIFF
--- a/vstgui/lib/platform/win32/direct2d/d2dbitmap.cpp
+++ b/vstgui/lib/platform/win32/direct2d/d2dbitmap.cpp
@@ -233,7 +233,7 @@ HBITMAP D2DBitmap::createHBitmap ()
 	pbmi.bmiHeader.biPlanes = 1;
 	pbmi.bmiHeader.biCompression = BI_RGB;
 	pbmi.bmiHeader.biWidth = (LONG)size.x;
-	pbmi.bmiHeader.biHeight = (LONG)size.y;
+	pbmi.bmiHeader.biHeight = -(LONG)size.y;
 	pbmi.bmiHeader.biBitCount = 32;
 
 	HDC hdc = GetDC (nullptr);


### PR DESCRIPTION
fix a bug that D2DBitmap::createHBitmap from CBitmap got a vertical mirror