### PR TITLE
disable D2DDrawContext::drawBitmap doing auto clip

### DIFF
--- a/vstgui/lib/platform/win32/direct2d/d2ddrawcontext.cpp
+++ b/vstgui/lib/platform/win32/direct2d/d2ddrawcontext.cpp
@@ -431,7 +431,7 @@ void D2DDrawContext::drawBitmap (CBitmap* bitmap, const CRect& dest, const CPoin
 {
 	if (renderTarget == nullptr)
 		return;
-	ConcatClip concatClip (*this, dest);
+	//ConcatClip concatClip (*this, dest);
 	D2DApplyClip ac (this);
 	if (ac.isEmpty ())
 		return;


### PR DESCRIPTION
…p, when a transform matrix such as a rotate matrix was set to the target GraphicContext, the clip will behave unexpected.