### PR TITLE
Fix IndexOutOfRangeException in d2dfont getFont()

### DIFF
--- a/vstgui/lib/platform/win32/direct2d/d2dfont.cpp
+++ b/vstgui/lib/platform/win32/direct2d/d2dfont.cpp
@@ -166,7 +166,7 @@ static COM::Ptr<IDWriteFont> getFont (IDWriteTextFormat* format, int32_t style)
 		return {};
 	UINT32 index = 0;
 	BOOL exists = FALSE;
-	if (FAILED (fontCollection->FindFamilyName (familyName.get (), &index, &exists)))
+	if (FAILED (fontCollection->FindFamilyName (familyName.get (), &index, &exists)) || !exists)
 		return {};
 	COM::Ptr<IDWriteFontFamily> fontFamily;
 	fontCollection->GetFontFamily (index, fontFamily.adoptPtr ());


### PR DESCRIPTION
A return value of S_OK from `IDWriteFontCollection::FindFamilyName()` does not mean that a matching font family was found; the `index` or `exists` value need to be checked before calling `GetFontFamily()` or an `IndexOutOfRangeException` can be thrown (and caught) within the latter function, since `index` is set to `UINT_MAX` if no matching family was found.

https://learn.microsoft.com/en-us/windows/win32/api/dwrite/nf-dwrite-idwritefontcollection-findfamilyname

Without this fix, log messages like the following are seen if font lookup fails:
```
Exception thrown at 0x00007FFC4FF1CF19 in VST3PluginTestHost.exe: Microsoft C++ exception: IndexOutOfRangeException at memory location 0x00000000001489E0.
Exception thrown at 0x00007FFC4FF1CF19 in VST3PluginTestHost.exe: Microsoft C++ exception: [rethrow] at memory location 0x0000000000000000.
```