### PR TITLE
Fix erroneous SetCapture after COptionMenu::onMouseDown

### DIFF
--- a/vstgui/lib/platform/win32/win32frame.cpp
+++ b/vstgui/lib/platform/win32/win32frame.cpp
@@ -816,7 +816,7 @@ LONG_PTR WINAPI Win32Frame::proc (HWND hwnd, UINT message, WPARAM wParam, LPARAM
 
 			event.mousePosition (GET_X_LPARAM (lParam), GET_Y_LPARAM (lParam));
 			pFrame->platformOnEvent (event);
-			if (event.consumed && getPlatformWindow ())
+			if (event.consumed && !event.ignoreFollowUpMoveAndUpEvents () && getPlatformWindow ())
 				SetCapture (getPlatformWindow ());
 			return 0;
 		}


### PR DESCRIPTION
Fixes #302 

`COptionMenu::onMouseDown` returns `kMouseDownEventHandledButDontNeedMovedOrUpEvents`

Prior to release 4.11, `Win32Frame::proc` would not call `SetCapture` in response:
https://github.com/steinbergmedia/vstgui/blob/6431f630f65f630c52ec1dfbb93d39d40600c41c/vstgui/lib/platform/win32/win32frame.cpp#L778-L779

In 4.11 and onwards, only `event.consumed` is being checked, so `kMouseDownEventHandledButDontNeedMovedOrUpEvents` results in a call to `SetCapture` which leads to the behavious described in #302:
https://github.com/steinbergmedia/vstgui/blob/addf12b9486fd9460a3abf2cf2a2dd96c44ed807/vstgui/lib/platform/win32/win32frame.cpp#L833-L834

This PR adds a `!event.ignoreFollowUpMoveAndUpEvents ()` check so that `SetCapture` is not called in response to `kMouseDownEventHandledButDontNeedMovedOrUpEvents`.