### PR TITLE
Apply bxjoscha's text rendering inconsistency fix

### DIFF
--- a/vstgui/lib/CMakeLists.txt
+++ b/vstgui/lib/CMakeLists.txt
@@ -3,6 +3,16 @@
 ##########################################################################################
 set(target vstgui)
 
+option(
+    VSTGUI_TEXTRENDERING_LEGACY_INCONSISTENCY
+    "Use the legacy platform inconsistency text rendering"
+    OFF
+)
+
+if(${VSTGUI_TEXTRENDERING_LEGACY_INCONSISTENCY})
+    target_compile_definitions(${target} PRIVATE VSTGUI_TEXTRENDERING_LEGACY_INCONSISTENCY=1)
+endif()
+
 set(${target}_common_sources
     animation/animations.cpp
     animation/animations.h

--- a/vstgui/lib/platform/mac/coregraphicsdevicecontext.mm
+++ b/vstgui/lib/platform/mac/coregraphicsdevicecontext.mm
@@ -356,6 +356,13 @@ struct CoreGraphicsDeviceContext::Impl
 	using BitmapDrawCountMap = std::map<CGBitmap*, int32_t>;
 	BitmapDrawCountMap bitmapDrawCount;
 
+#if defined(VSTGUI_TEXTRENDERING_LEGACY_INCONSISTENCY) &&                                          \
+	VSTGUI_TEXTRENDERING_LEGACY_INCONSISTENCY == 1
+	static constexpr bool shouldSmoothFonts = true;
+#else
+	static constexpr bool shouldSmoothFonts = false;
+#endif
+
 #if DEBUG
 	bool showClip {false};
 #endif
@@ -901,7 +908,7 @@ void CoreGraphicsDeviceContext::drawCTLine (CTLineRef line, CGPoint cgPoint, CTF
 		if (impl->state.drawMode.integralMode ())
 			cgPoint = impl->pixelAlligned (cgPoint);
 		CGContextSetShouldAntialias (context, antialias);
-		CGContextSetShouldSmoothFonts (context, true);
+		CGContextSetShouldSmoothFonts (context, impl->shouldSmoothFonts);
 		CGContextSetShouldSubpixelPositionFonts (context, true);
 		CGContextSetShouldSubpixelQuantizeFonts (context, true);
 		CGContextSetTextPosition (context, cgPoint.x, cgPoint.y);

--- a/vstgui/lib/platform/win32/direct2d/d2dgraphicscontext.cpp
+++ b/vstgui/lib/platform/win32/direct2d/d2dgraphicscontext.cpp
@@ -331,6 +331,13 @@ struct D2DGraphicsDeviceContext::Impl
 
 	const D2DGraphicsDevice& device;
 	COM::Ptr<ID2D1DeviceContext> deviceContext;
+
+#if defined(VSTGUI_TEXTRENDERING_LEGACY_INCONSISTENCY) &&                                          \
+	VSTGUI_TEXTRENDERING_LEGACY_INCONSISTENCY == 1
+	static constexpr auto antialiasMode = D2D1_TEXT_ANTIALIAS_MODE_CLEARTYPE;
+#else
+	static constexpr auto antialiasMode = D2D1_TEXT_ANTIALIAS_MODE_DEFAULT;
+#endif
 };
 
 //------------------------------------------------------------------------
@@ -844,7 +851,7 @@ void D2DGraphicsDeviceContext::drawTextLayout (IDWriteTextLayout* textLayout, CP
 											   CColor color, bool antialias)
 {
 	impl->doInContext ([&] (auto deviceContext) {
-		deviceContext->SetTextAntialiasMode (antialias ? D2D1_TEXT_ANTIALIAS_MODE_CLEARTYPE
+		deviceContext->SetTextAntialiasMode (antialias ? impl->antialiasMode
 													   : D2D1_TEXT_ANTIALIAS_MODE_ALIASED);
 		if (impl->state.drawMode.integralMode ())
 			pos.makeIntegral ();


### PR DESCRIPTION
There's a new cmake option 'VSTGUI_TEXTRENDERING_LEGACY_INCONSISTENCY' which can be enabled to get the old behaviour.

This fixes #298