### PR TITLE
Implementation of the radial gradient with cairo for Linux.

### DIFF
--- a/vstgui/lib/platform/linux/cairogradient.cpp
+++ b/vstgui/lib/platform/linux/cairogradient.cpp
@@ -49,7 +49,6 @@ const PatternHandle& Gradient::getRadialGradient (CPoint center, CCoord radius,
 {
 	if (!radialGradient)
 	{
-		auto end = center + originOffset;
 		radialGradient = PatternHandle (
 			cairo_pattern_create_radial (center.x, center.y, 0., center.x, center.y, radius));
 

--- a/vstgui/lib/platform/linux/cairogradient.cpp
+++ b/vstgui/lib/platform/linux/cairogradient.cpp
@@ -44,22 +44,25 @@ const PatternHandle& Gradient::getLinearGradient (CPoint start, CPoint end) cons
 }
 
 //------------------------------------------------------------------------
-const PatternHandle& Gradient::getRadialGradient ()
+const PatternHandle& Gradient::getRadialGradient (CPoint center, CCoord radius,
+												  CPoint originOffset) const
 {
 	if (!radialGradient)
 	{
-		radialGradient = PatternHandle (cairo_pattern_create_radial (0, 0, 1, 0, 0, 1));
+		auto end = center + originOffset;
+		radialGradient = PatternHandle (
+			cairo_pattern_create_radial (center.x, center.y, 0., center.x, center.y, radius));
+
 		for (auto& it : getColorStops ())
 		{
 			cairo_pattern_add_color_stop_rgba (
-			    radialGradient, it.first, it.second.normRed<double> (),
-			    it.second.normGreen<double> (), it.second.normBlue<double> (),
-			    it.second.normAlpha<double> ());
+				radialGradient, it.first, it.second.normRed<double> (),
+				it.second.normGreen<double> (), it.second.normBlue<double> (),
+				it.second.normAlpha<double> ());
 		}
 	}
 	return radialGradient;
 }
-
 //------------------------------------------------------------------------
 } // Cairo
 } // VSTGUI

--- a/vstgui/lib/platform/linux/cairogradient.h
+++ b/vstgui/lib/platform/linux/cairogradient.h
@@ -20,7 +20,8 @@ public:
 	~Gradient () noexcept override;
 
 	const PatternHandle& getLinearGradient (CPoint start, CPoint end) const;
-	const PatternHandle& getRadialGradient ();
+	const PatternHandle& getRadialGradient (CPoint center, CCoord radius,
+											CPoint originOffset) const;
 
 private:
 	void changed () override;


### PR DESCRIPTION
I followed this tutorial about gradients with cairo: https://zetcode.com/gfx/cairo/gradients/

I compared to Windows and with the same settings in the VSTGUI Live Editor I got identical looking results. Sometimes there is a "hickup": When moving around the view the radial gradient gets sticky and does not follow the view any longer. But when saving it "jumps" back into place.

Furthermore there is the ```originOffset```  argument of ```fillRadialGradient```. But I don't know what it is for. It is always (0,0) and I cannot make it change by any setting in VSTGUI Live Editor.