### PR TITLE
Fixed key event handling for OpenGL views on macOS

### DIFF
--- a/vstgui/lib/events.h
+++ b/vstgui/lib/events.h
@@ -479,6 +479,9 @@ enum class VirtualKey : uint32_t
 	Equals,
 	// DO NOT CHANGE THE ORDER ABOVE
 
+	SuperModifier, // The Control key on macOS
+	CapsLockModifier,
+	FunctionModifier, // The Function (fn) key on macOS
 };
 
 //------------------------------------------------------------------------
@@ -496,6 +499,15 @@ enum class ModifierKey : uint32_t
 	/** the super key (Control key on macOS, Windows key on Windows and Super key on other
 	   platforms)*/
 	Super = 1 << 3,
+
+	/** (macOS only) The Caps Lock key */
+	CapsLock = 1 << 4,
+	/** (macOS only) A key in the numeric keypad or an arrow key  */
+	NumPad = 1 << 5,
+	/** (macOS only) The Help key */
+	Help = 1 << 6,
+	/** (macOS only) The function key */
+	Fn = 1 << 7,
 
 	None = 0
 };

--- a/vstgui/lib/platform/mac/cocoa/cocoahelpers.h
+++ b/vstgui/lib/platform/mac/cocoa/cocoahelpers.h
@@ -18,6 +18,7 @@
 #define HIDDEN __attribute__((__visibility__("hidden")))
 
 //------------------------------------------------------------------------------------
+extern HIDDEN void SetModifierFlags (NSUInteger modifiers, VSTGUI::KeyboardEvent& event);
 extern HIDDEN bool CreateKeyboardEventFromNSEvent (NSEvent* theEvent, VSTGUI::KeyboardEvent& event);
 extern HIDDEN NSString* GetVirtualKeyCodeString (VSTGUI::VirtualKey virtualKey);
 extern HIDDEN int32_t eventButton (NSEvent* theEvent);
@@ -78,12 +79,20 @@ struct MacEventModifier
 		ShiftKeyMask = NSEventModifierFlagShift,
 		CommandKeyMask = NSEventModifierFlagCommand,
 		AlternateKeyMask = NSEventModifierFlagOption,
-		ControlKeyMask = NSEventModifierFlagControl
+		ControlKeyMask = NSEventModifierFlagControl,
+		CapsLockKeyMask = NSEventModifierFlagCapsLock,
+		NumericPadKeyMask = NSEventModifierFlagNumericPad,
+		HelpKeyMask = NSEventModifierFlagHelp,
+		FunctionKeyMask = NSEventModifierFlagFunction
 #else
 		ShiftKeyMask = NSShiftKeyMask,
 		CommandKeyMask = NSCommandKeyMask,
 		AlternateKeyMask = NSAlternateKeyMask,
-		ControlKeyMask = NSControlKeyMask
+		ControlKeyMask = NSControlKeyMask,
+		CapsLockKeyMask = NSAlphaShiftKeyMask,
+		NumericPadKeyMask = NSNumericPadKeyMask,
+		HelpKeyMask = NSHelpKeyMask,
+		FunctionKeyMask = NSFunctionKeyMask
 #endif
 	};
 };

--- a/vstgui/lib/platform/mac/cocoa/cocoaopenglview.mm
+++ b/vstgui/lib/platform/mac/cocoa/cocoaopenglview.mm
@@ -46,8 +46,26 @@ struct VSTGUI_NSOpenGLView : RuntimeObjCClass<VSTGUI_NSOpenGLView>
 			.addMethod (@selector (mouseMoved:), MouseXXX)
 			.addMethod (@selector (rightMouseDown:), MouseXXX)
 			.addMethod (@selector (rightMouseUp:), MouseXXX)
+			.addMethod (@selector (acceptsFirstResponder), acceptsFirstResponder)
+			.addMethod (@selector (becomeFirstResponder), becomeFirstResponder)
+			.addMethod (@selector (resignFirstResponder), resignFirstResponder)
 			.addIvar<CocoaOpenGLView*> (cocoaOpenGLViewVarName)
 			.finalize ();
+	}
+
+	static BOOL acceptsFirstResponder (id self, SEL _cmd)
+	{
+		return YES;
+	}
+
+	static BOOL becomeFirstResponder (id self, SEL _cmd)
+	{
+		return YES;
+	}
+
+	static BOOL resignFirstResponder (id self, SEL _cmd)
+	{
+		return YES;
 	}
 
 	//-----------------------------------------------------------------------------
@@ -305,6 +323,10 @@ void CocoaOpenGLView::viewSizeChanged (const CRect& visibleSize)
 		if ([platformView superview] == nil)
 		{
 			[parent addSubview:platformView];
+		}
+		else
+		{
+			[[platformView window] makeFirstResponder:parent];
 		}
 		unlockContext ();
 	}

--- a/vstgui/lib/platform/mac/cocoa/nsviewframe.mm
+++ b/vstgui/lib/platform/mac/cocoa/nsviewframe.mm
@@ -216,6 +216,7 @@ struct VSTGUI_NSView : RuntimeObjCClass<VSTGUI_NSView>
 			.addMethod (@selector (performKeyEquivalent:), performKeyEquivalent)
 			.addMethod (@selector (keyDown:), keyDown)
 			.addMethod (@selector (keyUp:), keyUp)
+			.addMethod (@selector (flagsChanged:), flagsChanged)
 			.addMethod (@selector (magnifyWithEvent:), magnifyWithEvent)
 			.addMethod (@selector (focusRingType), focusRingType)
 			.addMethod (@selector (draggingEntered:), draggingEntered)
@@ -681,6 +682,24 @@ struct VSTGUI_NSView : RuntimeObjCClass<VSTGUI_NSView>
 				return;
 		}
 		[[self nextResponder] keyUp:theEvent];
+	}
+
+	//------------------------------------------------------------------------------------
+	static void flagsChanged (id self, SEL _cmd, NSEvent* theEvent)
+	{
+		IPlatformFrameCallback* _vstguiframe = getFrame (self);
+		if (!_vstguiframe)
+			return;
+
+		KeyboardEvent keyEvent;
+		keyEvent.timestamp = static_cast<uint64_t> (theEvent.timestamp * 1000.);
+		if (CreateKeyboardEventFromNSEvent (theEvent, keyEvent))
+		{
+			_vstguiframe->platformOnEvent (keyEvent);
+			if (keyEvent.consumed)
+				return;
+		}
+		[[self nextResponder] flagsChanged:theEvent];
 	}
 
 	//------------------------------------------------------------------------------------


### PR DESCRIPTION
- Fixed Logic Pro & GarageBand not handling key events after resizing the view
- Added support for flagsChanged
- Implemented all key modifier flags on macOS for completeness

The `acceptsFirstResponder`, `becomeFirstResponder` and `resignFirstResponder` methods in the opengl class make it possible for keyboard events to be caught by the (parent) view, otherwise it doesn't work if we don't have them.

The line in `CocoaOpenGLView::viewSizeChanged()` fixes an issue in Logic Pro and GarageBand where when you change the view size, the key event handling stops working even though the opengl view is still the first responder. Making the parent view the first responder fixes this problem. When you click on the opengl view, it becomes the first responder again and key events work.

> The flagsChanged: method can be useful for detecting the pressing of modifier keys without any other key being pressed simultaneously. For example, if the user presses the Option key by itself, your responder object can detect this in its implementation of flagsChanged.
[Source](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/EventOverview/HandlingKeyEvents/HandlingKeyEvents.html)

I had to implement all key modifier flags on macOS for the fake/simulated keyUp event in `flagsChanged` to work properly:
https://developer.apple.com/documentation/appkit/nseventmodifierflags

I have been testing this on Reaper, Ableton Live, Logic Pro and GarageBand.