### PR TITLE
Fix rendering of VirtualKey::Back in Cocoa menu items

### DIFF
--- a/vstgui/lib/platform/mac/cocoa/cocoahelpers.mm
+++ b/vstgui/lib/platform/mac/cocoa/cocoahelpers.mm
@@ -137,7 +137,7 @@ HIDDEN NSString* GetVirtualKeyCodeString (VirtualKey virtualKey)
 	unichar character = 0;
 	switch (virtualKey)
 	{
-		case VirtualKey::Back: character = NSDeleteCharacter; break;
+		case VirtualKey::Back: character = NSBackspaceCharacter; break;
 		case VirtualKey::Tab: character = NSTabCharacter; break;
 		case VirtualKey::Clear: character = NSClearLineFunctionKey; break;
 		case VirtualKey::Return: character = NSCarriageReturnCharacter; break;


### PR DESCRIPTION
Menu items configured with `setVirtualKey(VSTGUI::VirtualKey::Back)` were incorrectly showing the delete symbol instead.

This change makes menu items show the symbol that matches the backspace key on Mac keyboards;

![Screenshot 2024-01-17 at 16 42 48](https://github.com/steinbergmedia/vstgui/assets/61777/f8399a61-99ea-49fa-a28a-5f34ab33bc99)
