### PR TITLE
Implementation of an Auto Layout in Row Column View Container

### DIFF
--- a/vstgui/lib/crowcolumnview.h
+++ b/vstgui/lib/crowcolumnview.h
@@ -54,7 +54,17 @@ public:
 		/** subviews have the same right or bottom position */
 		kRightBottomEqualy,
 		/** stretch subviews to the same width and height */
-		kStretchEqualy
+		kStretchEqualy,
+
+		kTopLeft,
+		kTopCenter,
+		kTopRight,
+		kMiddleLeft,
+		kMiddleCenter,
+		kMiddleRight,
+		kBottomLeft,
+		kBottomCenter,
+		kBottomRight
 	};
 
 	CRowColumnView (const CRect& size, Style style = kRowStyle, LayoutStyle layoutStyle = kLeftTopEqualy, CCoord spacing = 0., const CRect& margin = CRect (0., 0., 0., 0.));

--- a/vstgui/tests/unittest/lib/crowcolumnview_test.cpp
+++ b/vstgui/tests/unittest/lib/crowcolumnview_test.cpp
@@ -14,6 +14,7 @@ using Rects = std::vector<CRect>;
 static const CRect templateSize (0., 0., 100., 100.);
 static const CRect layoutSize (0., 0., 80., 80.);
 
+// clang-format off
 static const Rects childrenDefaultSizes = {
     {0., 0., 10., 10.},
     {0., 0., 20., 20.},
@@ -85,74 +86,75 @@ static const std::map<CRowColumnView::LayoutStyle, Rects> kChildrenResultSizes =
         }
     }
 };
+// clang-format on
 
-auto testWithLayoutStyle(const CRowColumnView::LayoutStyle layoutStyle) -> void
+auto testWithLayoutStyle (const CRowColumnView::LayoutStyle layoutStyle) -> void
 {
-    auto rowColumnView = owned (new CRowColumnView(layoutSize));
-    rowColumnView->setStyle(CRowColumnView::kRowStyle);
-    rowColumnView->setLayoutStyle(layoutStyle);
-    
-    for(auto& rect : childrenDefaultSizes)
-    {
-        auto child = new CView(rect);
-        rowColumnView->CViewContainer::addView(child);
-        rowColumnView->layoutViews();
-    }
-    
-    //rowColumnView->layoutViews();
-    size_t i = 0;
-    rowColumnView->forEachChild([&](CView* child){
-        const auto& results = kChildrenResultSizes.find(layoutStyle);
-        const auto& childrenResults = results->second;
-        auto viewSize = child->getViewSize();
-        EXPECT (viewSize == childrenResults.at(i))
-        i++;
-    });
+	auto rowColumnView = owned (new CRowColumnView (layoutSize));
+	rowColumnView->setStyle (CRowColumnView::kRowStyle);
+	rowColumnView->setLayoutStyle (layoutStyle);
+
+	for (auto& rect : childrenDefaultSizes)
+	{
+		auto child = new CView (rect);
+		rowColumnView->CViewContainer::addView (child);
+		rowColumnView->layoutViews ();
+	}
+
+	// rowColumnView->layoutViews();
+	size_t i = 0;
+	rowColumnView->forEachChild ([&] (CView* child) {
+		const auto& results = kChildrenResultSizes.find (layoutStyle);
+		const auto& childrenResults = results->second;
+		auto viewSize = child->getViewSize ();
+		EXPECT (viewSize == childrenResults.at (i))
+		i++;
+	});
 }
 
 TEST_CASE (CRowColumnViewTest, LayoutTopLeftStyle)
 {
-    //testWithLayoutStyle(CRowColumnView::kTopLeft);
+	// testWithLayoutStyle(CRowColumnView::kTopLeft);
 }
 
 TEST_CASE (CRowColumnViewTest, LayoutTopCenterStyle)
 {
-    testWithLayoutStyle(CRowColumnView::kTopCenter);
+	testWithLayoutStyle (CRowColumnView::kTopCenter);
 }
 
 TEST_CASE (CRowColumnViewTest, LayoutTopRightStyle)
 {
-    testWithLayoutStyle(CRowColumnView::kTopRight);
+	testWithLayoutStyle (CRowColumnView::kTopRight);
 }
 
 TEST_CASE (CRowColumnViewTest, LayoutMiddleLeftStyle)
 {
-    testWithLayoutStyle(CRowColumnView::kMiddleLeft);
+	testWithLayoutStyle (CRowColumnView::kMiddleLeft);
 }
 
 TEST_CASE (CRowColumnViewTest, LayoutMiddleCenterStyle)
 {
-    testWithLayoutStyle(CRowColumnView::kMiddleCenter);
+	testWithLayoutStyle (CRowColumnView::kMiddleCenter);
 }
 
 TEST_CASE (CRowColumnViewTest, LayoutMiddleRightStyle)
 {
-    testWithLayoutStyle(CRowColumnView::kMiddleRight);
+	testWithLayoutStyle (CRowColumnView::kMiddleRight);
 }
 
 TEST_CASE (CRowColumnViewTest, LayoutBottomLeftStyle)
 {
-    testWithLayoutStyle(CRowColumnView::kBottomLeft);
+	testWithLayoutStyle (CRowColumnView::kBottomLeft);
 }
 
 TEST_CASE (CRowColumnViewTest, LayoutBottomCenterStyle)
 {
-    testWithLayoutStyle(CRowColumnView::kBottomCenter);
+	testWithLayoutStyle (CRowColumnView::kBottomCenter);
 }
 
 TEST_CASE (CRowColumnViewTest, LayoutBottomRightStyle)
 {
-    testWithLayoutStyle(CRowColumnView::kBottomRight);
+	testWithLayoutStyle (CRowColumnView::kBottomRight);
 }
 
 } // VSTGUI

--- a/vstgui/tests/unittest/lib/crowcolumnview_test.cpp
+++ b/vstgui/tests/unittest/lib/crowcolumnview_test.cpp
@@ -1,0 +1,158 @@
+// This file is part of VSTGUI. It is subject to the license terms
+// in the LICENSE file found in the top-level directory of this
+// distribution and at http://github.com/steinbergmedia/vstgui/LICENSE
+
+#include "../../../lib/crowcolumnview.h"
+#include "../unittests.h"
+#include <vector>
+#include <map>
+
+namespace VSTGUI {
+
+using Rects = std::vector<CRect>;
+
+static const CRect templateSize (0., 0., 100., 100.);
+static const CRect layoutSize (0., 0., 80., 80.);
+
+static const Rects childrenDefaultSizes = {
+    {0., 0., 10., 10.},
+    {0., 0., 20., 20.},
+    {0., 0., 30., 30.}
+};
+
+static const std::map<CRowColumnView::LayoutStyle, Rects> kChildrenResultSizes = {
+    {
+        CRowColumnView::kTopLeft, {
+            {0., 0., 10., 10.},
+            {0., 10., 20., 30.},
+            {0., 30., 30., 60.}
+        }
+    },
+    {
+        CRowColumnView::kTopCenter, {
+            {35., 0., 45., 10.},
+            {30., 10., 50., 30.},
+            {25., 30., 55., 60.}
+        }
+    },
+    {
+        CRowColumnView::kTopRight, {
+            {70., 0., 80., 10.},
+            {60., 10., 80., 30.},
+            {50., 30., 80., 60.}
+        }
+    },
+    {
+        CRowColumnView::kMiddleLeft, {
+            {0., 10., 10., 20.},
+            {0., 20., 20., 40.},
+            {0., 40., 30., 70.}
+        }
+    },
+    {
+        CRowColumnView::kMiddleCenter, {
+            {35., 10., 45., 20.},
+            {30., 20., 50., 40.},
+            {25., 40., 55., 70.}
+        }
+    },
+    {
+        CRowColumnView::kMiddleRight, {
+            {70., 10., 80., 20.},
+            {60., 20., 80., 40.},
+            {50., 40., 80., 70.}
+        }
+    },
+    {
+        CRowColumnView::kBottomLeft, {
+            {0., 20., 10., 30.},
+            {0., 30., 20., 50.},
+            {0., 50., 30., 80.}
+        }
+    },
+    {
+        CRowColumnView::kBottomCenter, {
+            {35., 20., 45., 30.},
+            {30., 30., 50., 50.},
+            {25., 50., 55., 80.}
+        }
+    },
+    {
+        CRowColumnView::kBottomRight, {
+            {70., 20., 80., 30.},
+            {60., 30., 80., 50.},
+            {50., 50., 80., 80.}
+        }
+    }
+};
+
+auto testWithLayoutStyle(const CRowColumnView::LayoutStyle layoutStyle) -> void
+{
+    auto rowColumnView = owned (new CRowColumnView(layoutSize));
+    rowColumnView->setStyle(CRowColumnView::kRowStyle);
+    rowColumnView->setLayoutStyle(layoutStyle);
+    
+    for(auto& rect : childrenDefaultSizes)
+    {
+        auto child = new CView(rect);
+        rowColumnView->CViewContainer::addView(child);
+        rowColumnView->layoutViews();
+    }
+    
+    //rowColumnView->layoutViews();
+    size_t i = 0;
+    rowColumnView->forEachChild([&](CView* child){
+        const auto& results = kChildrenResultSizes.find(layoutStyle);
+        const auto& childrenResults = results->second;
+        auto viewSize = child->getViewSize();
+        EXPECT (viewSize == childrenResults.at(i))
+        i++;
+    });
+}
+
+TEST_CASE (CRowColumnViewTest, LayoutTopLeftStyle)
+{
+    //testWithLayoutStyle(CRowColumnView::kTopLeft);
+}
+
+TEST_CASE (CRowColumnViewTest, LayoutTopCenterStyle)
+{
+    testWithLayoutStyle(CRowColumnView::kTopCenter);
+}
+
+TEST_CASE (CRowColumnViewTest, LayoutTopRightStyle)
+{
+    testWithLayoutStyle(CRowColumnView::kTopRight);
+}
+
+TEST_CASE (CRowColumnViewTest, LayoutMiddleLeftStyle)
+{
+    testWithLayoutStyle(CRowColumnView::kMiddleLeft);
+}
+
+TEST_CASE (CRowColumnViewTest, LayoutMiddleCenterStyle)
+{
+    testWithLayoutStyle(CRowColumnView::kMiddleCenter);
+}
+
+TEST_CASE (CRowColumnViewTest, LayoutMiddleRightStyle)
+{
+    testWithLayoutStyle(CRowColumnView::kMiddleRight);
+}
+
+TEST_CASE (CRowColumnViewTest, LayoutBottomLeftStyle)
+{
+    testWithLayoutStyle(CRowColumnView::kBottomLeft);
+}
+
+TEST_CASE (CRowColumnViewTest, LayoutBottomCenterStyle)
+{
+    testWithLayoutStyle(CRowColumnView::kBottomCenter);
+}
+
+TEST_CASE (CRowColumnViewTest, LayoutBottomRightStyle)
+{
+    testWithLayoutStyle(CRowColumnView::kBottomRight);
+}
+
+} // VSTGUI

--- a/vstgui/tests/unittest/lib/crowcolumnview_test.cpp
+++ b/vstgui/tests/unittest/lib/crowcolumnview_test.cpp
@@ -21,7 +21,9 @@ static const Rects childrenDefaultSizes = {
     {0., 0., 30., 30.}
 };
 
-static const std::map<CRowColumnView::LayoutStyle, Rects> kChildrenResultSizes = {
+using ExpectedResults = std::map<CRowColumnView::LayoutStyle, Rects>;
+
+static const ExpectedResults kRowLayoutChildrenResultSizes = {
     {
         CRowColumnView::kTopLeft, {
             {0., 0., 10., 10.},
@@ -87,7 +89,73 @@ static const std::map<CRowColumnView::LayoutStyle, Rects> kChildrenResultSizes =
     }
 };
 
-static const std::map<CRowColumnView::LayoutStyle, Rects> kChildrenResultSizesWithSpacing = {
+static const ExpectedResults kColumnLayoutChildrenResultSizes = {
+    {
+        CRowColumnView::kTopLeft, {
+            {0., 0., 10., 10.},
+            {10., 0., 30., 20.},
+            {30., 0., 60., 30.}
+        }
+    },
+    {
+        CRowColumnView::kTopCenter, {
+            {10., 0., 20., 10.},
+            {20., 0., 40., 20.},
+            {40., 0., 70., 30.}
+        }
+    },
+    {
+        CRowColumnView::kTopRight, {
+            {20., 0., 30., 10.},
+            {30., 0., 50., 20.},
+            {50., 0., 80., 30.}
+        }
+    },
+    {
+        CRowColumnView::kMiddleLeft, {
+            {0., 35., 10., 45.},
+            {10., 30., 30., 50.},
+            {30., 25., 60., 55.}
+        }
+    },
+    {
+        CRowColumnView::kMiddleCenter, {
+            {10., 35., 20., 45.},
+            {20., 30., 40., 50.},
+            {40., 25., 70., 55.}
+        }
+    },
+    {
+        CRowColumnView::kMiddleRight, {
+            {20., 35., 30., 45.},
+            {30., 30., 50., 50.},
+            {50., 25., 80., 55.}
+        }
+    },
+    {
+        CRowColumnView::kBottomLeft, {
+            {0., 70., 10., 80.},
+            {10., 60., 30., 80.},
+            {30., 50., 60., 80.}
+        }
+    },
+    {
+        CRowColumnView::kBottomCenter, {
+            {10., 70., 20., 80.},
+            {20., 60., 40., 80.},
+            {40., 50., 70., 80.}
+        }
+    },
+    {
+        CRowColumnView::kBottomRight, {
+            {20., 70., 30., 80.},
+            {30., 60., 50., 80.},
+            {50., 50., 80., 80.}
+        }
+    }
+};
+
+static const ExpectedResults kRowLayoutChildrenResultSizesWithSpacing = {
     {
         CRowColumnView::kMiddleCenter, {
             {35., 6., 45., 16.},
@@ -98,16 +166,21 @@ static const std::map<CRowColumnView::LayoutStyle, Rects> kChildrenResultSizesWi
 };
 // clang-format on
 
-auto testWithLayoutStyle (const CRowColumnView::LayoutStyle layoutStyle,
-						  double spacing = 0.) -> void
+struct TestData
 {
-	const auto& results = spacing == 0. ? kChildrenResultSizes.find (layoutStyle)
-										: kChildrenResultSizesWithSpacing.find (layoutStyle);
+	CRowColumnView::LayoutStyle layoutStyle = CRowColumnView::LayoutStyle::kTopLeft;
+	CRowColumnView::Style style = CRowColumnView::Style::kRowStyle;
+	double spacing = 0.;
+	ExpectedResults expected;
+};
 
+auto testWithLayoutStyle (const TestData& testData) -> void
+{
+	const auto& expected = testData.expected.find (testData.layoutStyle)->second;
 	auto rowColumnView = owned (new CRowColumnView (layoutSize));
-	rowColumnView->setStyle (CRowColumnView::kRowStyle);
-	rowColumnView->setLayoutStyle (layoutStyle);
-	rowColumnView->setSpacing (spacing);
+	rowColumnView->setStyle (testData.style);
+	rowColumnView->setLayoutStyle (testData.layoutStyle);
+	rowColumnView->setSpacing (testData.spacing);
 
 	for (auto& rect : childrenDefaultSizes)
 	{
@@ -116,64 +189,127 @@ auto testWithLayoutStyle (const CRowColumnView::LayoutStyle layoutStyle,
 		rowColumnView->layoutViews ();
 	}
 
-	// rowColumnView->layoutViews();
 	size_t i = 0;
 	rowColumnView->forEachChild ([&] (CView* child) {
-		const auto& childrenResults = results->second;
+		const auto& childrenResults = testData.expected.find (testData.layoutStyle);
 		auto viewSize = child->getViewSize ();
-		EXPECT (viewSize == childrenResults.at (i))
+		EXPECT (viewSize == expected.at (i))
 		i++;
 	});
 }
 
-TEST_CASE (CRowColumnViewTest, LayoutTopLeftStyle)
+TEST_CASE (CRowColumnViewTest, RowLayoutTopLeftStyle)
 {
-	// testWithLayoutStyle(CRowColumnView::kTopLeft);
+	testWithLayoutStyle (
+		{CRowColumnView::kTopLeft, CRowColumnView::kRowStyle, 0., kRowLayoutChildrenResultSizes});
 }
 
-TEST_CASE (CRowColumnViewTest, LayoutTopCenterStyle)
+TEST_CASE (CRowColumnViewTest, RowLayoutTopCenterStyle)
 {
-	testWithLayoutStyle (CRowColumnView::kTopCenter);
+	testWithLayoutStyle (
+		{CRowColumnView::kTopCenter, CRowColumnView::kRowStyle, 0., kRowLayoutChildrenResultSizes});
 }
 
-TEST_CASE (CRowColumnViewTest, LayoutTopRightStyle)
+TEST_CASE (CRowColumnViewTest, RowLayoutTopRightStyle)
 {
-	testWithLayoutStyle (CRowColumnView::kTopRight);
+	testWithLayoutStyle (
+		{CRowColumnView::kTopRight, CRowColumnView::kRowStyle, 0., kRowLayoutChildrenResultSizes});
 }
 
-TEST_CASE (CRowColumnViewTest, LayoutMiddleLeftStyle)
+TEST_CASE (CRowColumnViewTest, RowLayoutMiddleLeftStyle)
 {
-	testWithLayoutStyle (CRowColumnView::kMiddleLeft);
+	testWithLayoutStyle ({CRowColumnView::kMiddleLeft, CRowColumnView::kRowStyle, 0.,
+						  kRowLayoutChildrenResultSizes});
 }
 
-TEST_CASE (CRowColumnViewTest, LayoutMiddleCenterStyle)
+TEST_CASE (CRowColumnViewTest, RowLayoutMiddleCenterStyle)
 {
-	testWithLayoutStyle (CRowColumnView::kMiddleCenter);
+	testWithLayoutStyle ({CRowColumnView::kMiddleCenter, CRowColumnView::kRowStyle, 0.,
+						  kRowLayoutChildrenResultSizes});
 }
 
-TEST_CASE (CRowColumnViewTest, LayoutMiddleRightStyle)
+TEST_CASE (CRowColumnViewTest, RowLayoutMiddleRightStyle)
 {
-	testWithLayoutStyle (CRowColumnView::kMiddleRight);
+	testWithLayoutStyle ({CRowColumnView::kMiddleRight, CRowColumnView::kRowStyle, 0.,
+						  kRowLayoutChildrenResultSizes});
 }
 
-TEST_CASE (CRowColumnViewTest, LayoutBottomLeftStyle)
+TEST_CASE (CRowColumnViewTest, RowLayoutBottomLeftStyle)
 {
-	testWithLayoutStyle (CRowColumnView::kBottomLeft);
+	testWithLayoutStyle ({CRowColumnView::kBottomLeft, CRowColumnView::kRowStyle, 0.,
+						  kRowLayoutChildrenResultSizes});
 }
 
-TEST_CASE (CRowColumnViewTest, LayoutBottomCenterStyle)
+TEST_CASE (CRowColumnViewTest, RowLayoutBottomCenterStyle)
 {
-	testWithLayoutStyle (CRowColumnView::kBottomCenter);
+	testWithLayoutStyle ({CRowColumnView::kBottomCenter, CRowColumnView::kRowStyle, 0.,
+						  kRowLayoutChildrenResultSizes});
 }
 
-TEST_CASE (CRowColumnViewTest, LayoutBottomRightStyle)
+TEST_CASE (CRowColumnViewTest, RowLayoutBottomRightStyle)
 {
-	testWithLayoutStyle (CRowColumnView::kBottomRight);
+	testWithLayoutStyle ({CRowColumnView::kBottomRight, CRowColumnView::kRowStyle, 0.,
+						  kRowLayoutChildrenResultSizes});
 }
 
-TEST_CASE (CRowColumnViewTest, LayoutMiddleCenterStyleWithSpacing)
+TEST_CASE (CRowColumnViewTest, ColumnLayoutTopLeftStyle)
 {
-	testWithLayoutStyle (CRowColumnView::kMiddleCenter, 4.);
+	testWithLayoutStyle ({CRowColumnView::kTopLeft, CRowColumnView::kColumnStyle, 0.,
+						  kColumnLayoutChildrenResultSizes});
+}
+
+TEST_CASE (CRowColumnViewTest, ColumnLayoutTopCenterStyle)
+{
+	testWithLayoutStyle ({CRowColumnView::kTopCenter, CRowColumnView::kColumnStyle, 0.,
+						  kColumnLayoutChildrenResultSizes});
+}
+
+TEST_CASE (CRowColumnViewTest, ColumnLayoutTopRightStyle)
+{
+	testWithLayoutStyle ({CRowColumnView::kTopRight, CRowColumnView::kColumnStyle, 0.,
+						  kColumnLayoutChildrenResultSizes});
+}
+
+TEST_CASE (CRowColumnViewTest, ColumnLayoutMiddleLeftStyle)
+{
+	testWithLayoutStyle ({CRowColumnView::kMiddleLeft, CRowColumnView::kColumnStyle, 0.,
+						  kColumnLayoutChildrenResultSizes});
+}
+
+TEST_CASE (CRowColumnViewTest, ColumnLayoutMiddleCenterStyle)
+{
+	testWithLayoutStyle ({CRowColumnView::kMiddleCenter, CRowColumnView::kColumnStyle, 0.,
+						  kColumnLayoutChildrenResultSizes});
+}
+
+TEST_CASE (CRowColumnViewTest, ColumnLayoutMiddleRightStyle)
+{
+	testWithLayoutStyle ({CRowColumnView::kMiddleRight, CRowColumnView::kColumnStyle, 0.,
+						  kColumnLayoutChildrenResultSizes});
+}
+
+TEST_CASE (CRowColumnViewTest, ColumnLayoutBottomLeftStyle)
+{
+	testWithLayoutStyle ({CRowColumnView::kBottomLeft, CRowColumnView::kColumnStyle, 0.,
+						  kColumnLayoutChildrenResultSizes});
+}
+
+TEST_CASE (CRowColumnViewTest, ColumnLayoutBottomCenterStyle)
+{
+	testWithLayoutStyle ({CRowColumnView::kBottomCenter, CRowColumnView::kColumnStyle, 0.,
+						  kColumnLayoutChildrenResultSizes});
+}
+
+TEST_CASE (CRowColumnViewTest, ColumnLayoutBottomRightStyle)
+{
+	testWithLayoutStyle ({CRowColumnView::kBottomRight, CRowColumnView::kColumnStyle, 0.,
+						  kColumnLayoutChildrenResultSizes});
+}
+
+TEST_CASE (CRowColumnViewTest, RowLayoutMiddleCenterStyleWithSpacing)
+{
+	testWithLayoutStyle ({CRowColumnView::kMiddleCenter, CRowColumnView::kRowStyle, 4.,
+						  kRowLayoutChildrenResultSizesWithSpacing});
 }
 
 } // VSTGUI

--- a/vstgui/tests/unittest/lib/crowcolumnview_test.cpp
+++ b/vstgui/tests/unittest/lib/crowcolumnview_test.cpp
@@ -86,13 +86,28 @@ static const std::map<CRowColumnView::LayoutStyle, Rects> kChildrenResultSizes =
         }
     }
 };
+
+static const std::map<CRowColumnView::LayoutStyle, Rects> kChildrenResultSizesWithSpacing = {
+    {
+        CRowColumnView::kMiddleCenter, {
+            {35., 6., 45., 16.},
+            {30., 20., 50., 40.},
+            {25., 44., 55., 74.}
+        }
+    }
+};
 // clang-format on
 
-auto testWithLayoutStyle (const CRowColumnView::LayoutStyle layoutStyle) -> void
+auto testWithLayoutStyle (const CRowColumnView::LayoutStyle layoutStyle,
+						  double spacing = 0.) -> void
 {
+	const auto& results = spacing == 0. ? kChildrenResultSizes.find (layoutStyle)
+										: kChildrenResultSizesWithSpacing.find (layoutStyle);
+
 	auto rowColumnView = owned (new CRowColumnView (layoutSize));
 	rowColumnView->setStyle (CRowColumnView::kRowStyle);
 	rowColumnView->setLayoutStyle (layoutStyle);
+	rowColumnView->setSpacing (spacing);
 
 	for (auto& rect : childrenDefaultSizes)
 	{
@@ -104,7 +119,6 @@ auto testWithLayoutStyle (const CRowColumnView::LayoutStyle layoutStyle) -> void
 	// rowColumnView->layoutViews();
 	size_t i = 0;
 	rowColumnView->forEachChild ([&] (CView* child) {
-		const auto& results = kChildrenResultSizes.find (layoutStyle);
 		const auto& childrenResults = results->second;
 		auto viewSize = child->getViewSize ();
 		EXPECT (viewSize == childrenResults.at (i))
@@ -155,6 +169,11 @@ TEST_CASE (CRowColumnViewTest, LayoutBottomCenterStyle)
 TEST_CASE (CRowColumnViewTest, LayoutBottomRightStyle)
 {
 	testWithLayoutStyle (CRowColumnView::kBottomRight);
+}
+
+TEST_CASE (CRowColumnViewTest, LayoutMiddleCenterStyleWithSpacing)
+{
+	testWithLayoutStyle (CRowColumnView::kMiddleCenter, 4.);
 }
 
 } // VSTGUI

--- a/vstgui/tests/unittest/uidescription/uiviewcreator/crowcolumnviewcreator_test.cpp
+++ b/vstgui/tests/unittest/uidescription/uiviewcreator/crowcolumnviewcreator_test.cpp
@@ -16,82 +16,84 @@ using namespace UIViewCreator;
 TEST_CASE (CRowColumnViewCreatorTest, RowStyle)
 {
 	testAttribute<CRowColumnView> (
-	    kCRowColumnView, kAttrRowStyle, true, nullptr,
-	    [] (CRowColumnView* v) { return v->getStyle () == CRowColumnView::kRowStyle; });
+		kCRowColumnView, kAttrRowStyle, true, nullptr,
+		[] (CRowColumnView* v) { return v->getStyle () == CRowColumnView::kRowStyle; });
 }
 
 TEST_CASE (CRowColumnViewCreatorTest, ColumnStyle)
 {
 	testAttribute<CRowColumnView> (
-	    kCRowColumnView, kAttrRowStyle, false, nullptr,
-	    [] (CRowColumnView* v) { return v->getStyle () == CRowColumnView::kColumnStyle; });
+		kCRowColumnView, kAttrRowStyle, false, nullptr,
+		[] (CRowColumnView* v) { return v->getStyle () == CRowColumnView::kColumnStyle; });
 }
 
 TEST_CASE (CRowColumnViewCreatorTest, Spacing)
 {
 	testAttribute<CRowColumnView> (kCRowColumnView, kAttrSpacing, 5., nullptr,
-	                               [] (CRowColumnView* v) { return v->getSpacing () == 5.; });
+								   [] (CRowColumnView* v) { return v->getSpacing () == 5.; });
 }
 
 TEST_CASE (CRowColumnViewCreatorTest, Margin)
 {
 	CRect margin (5, 6, 7, 8);
 	testAttribute<CRowColumnView> (kCRowColumnView, kAttrMargin, margin, nullptr,
-	                               [&] (CRowColumnView* v) { return v->getMargin () == margin; });
+								   [&] (CRowColumnView* v) { return v->getMargin () == margin; });
 }
 
 TEST_CASE (CRowColumnViewCreatorTest, AnimateViewResizing)
 {
 	testAttribute<CRowColumnView> (kCRowColumnView, kAttrAnimateViewResizing, true, nullptr,
-	                               [] (CRowColumnView* v) { return v->isAnimateViewResizing (); });
+								   [] (CRowColumnView* v) { return v->isAnimateViewResizing (); });
 }
 
 TEST_CASE (CRowColumnViewCreatorTest, EqualSizeLayoutStretch)
 {
 	testAttribute<CRowColumnView> (
-	    kCRowColumnView, kAttrEqualSizeLayout, "stretch", nullptr,
-	    [] (CRowColumnView* v) { return v->getLayoutStyle () == CRowColumnView::kStretchEqualy; });
+		kCRowColumnView, kAttrEqualSizeLayout, "stretch", nullptr,
+		[] (CRowColumnView* v) { return v->getLayoutStyle () == CRowColumnView::kStretchEqualy; });
 }
 
 TEST_CASE (CRowColumnViewCreatorTest, EqualSizeLayoutCenter)
 {
 	testAttribute<CRowColumnView> (
-	    kCRowColumnView, kAttrEqualSizeLayout, "center", nullptr,
-	    [] (CRowColumnView* v) { return v->getLayoutStyle () == CRowColumnView::kCenterEqualy; });
+		kCRowColumnView, kAttrEqualSizeLayout, "center", nullptr,
+		[] (CRowColumnView* v) { return v->getLayoutStyle () == CRowColumnView::kCenterEqualy; });
 }
 
 TEST_CASE (CRowColumnViewCreatorTest, EqualSizeLayoutRightBottom)
 {
 	testAttribute<CRowColumnView> (
-	    kCRowColumnView, kAttrEqualSizeLayout, "right-bottom", nullptr, [] (CRowColumnView* v) {
-		    return v->getLayoutStyle () == CRowColumnView::kRightBottomEqualy;
-	    });
+		kCRowColumnView, kAttrEqualSizeLayout, "right-bottom", nullptr, [] (CRowColumnView* v) {
+			return v->getLayoutStyle () == CRowColumnView::kRightBottomEqualy;
+		});
 }
 
 TEST_CASE (CRowColumnViewCreatorTest, EqualSizeLayoutLeftTop)
 {
 	testAttribute<CRowColumnView> (
-	    kCRowColumnView, kAttrEqualSizeLayout, "left-top", nullptr,
-	    [] (CRowColumnView* v) { return v->getLayoutStyle () == CRowColumnView::kLeftTopEqualy; });
+		kCRowColumnView, kAttrEqualSizeLayout, "left-top", nullptr,
+		[] (CRowColumnView* v) { return v->getLayoutStyle () == CRowColumnView::kLeftTopEqualy; });
 }
 
 TEST_CASE (CRowColumnViewCreatorTest, AnimationTime)
 {
 	testAttribute<CRowColumnView> (
-	    kCRowColumnView, kAttrViewResizeAnimationTime, 100, nullptr,
-	    [] (CRowColumnView* v) { return v->getViewResizeAnimationTime () == 100; });
+		kCRowColumnView, kAttrViewResizeAnimationTime, 100, nullptr,
+		[] (CRowColumnView* v) { return v->getViewResizeAnimationTime () == 100; });
 }
 
 TEST_CASE (CRowColumnViewCreatorTest, EqualSizeLayoutValues)
 {
 	testPossibleValues (kCRowColumnView, kAttrEqualSizeLayout, nullptr,
-	                    {"left-top", "stretch", "center", "right-bottom"});
+						{"left-top", "stretch", "center", "right-bottom", "top-left", "top-center",
+						 "top-right", "middle-left", "middle-center", "middle-right", "bottom-left",
+						 "bottom-center", "bottom-right"});
 }
 
 TEST_CASE (CRowColumnViewCreatorTest, HideClippedSubviews)
 {
 	testAttribute<CRowColumnView> (kCRowColumnView, kAttrHideClippedSubviews, true, nullptr,
-	                               [] (CRowColumnView* v) { return v->hideClippedSubviews (); });
+								   [] (CRowColumnView* v) { return v->hideClippedSubviews (); });
 }
 
 } // VSTGUI

--- a/vstgui/uidescription/viewcreator/rowcolumnviewcreator.cpp
+++ b/vstgui/uidescription/viewcreator/rowcolumnviewcreator.cpp
@@ -18,7 +18,10 @@ namespace UIViewCreator {
 //------------------------------------------------------------------------
 auto RowColumnViewCreator::layoutStrings () -> LayoutStrings&
 {
-	static LayoutStrings strings = {"left-top", "center", "right-bottom", "stretch"};
+	static LayoutStrings strings = {
+		"left-top",	   "center",		"right-bottom", "stretch",		 "top-left",
+		"top-center",  "top-right",		"middle-left",	"middle-center", "middle-right",
+		"bottom-left", "bottom-center", "bottom-right"};
 	return strings;
 }
 
@@ -81,7 +84,7 @@ bool RowColumnViewCreator::apply (CView* view, const UIAttributes& attributes,
 	attr = attributes.getAttributeValue (kAttrEqualSizeLayout);
 	if (attr)
 	{
-		for (auto index = 0u; index <= CRowColumnView::kStretchEqualy; ++index)
+		for (auto index = 0u; index <= CRowColumnView::kBottomRight; ++index)
 		{
 			if (*attr == layoutStrings ()[index])
 			{

--- a/vstgui/uidescription/viewcreator/rowcolumnviewcreator.h
+++ b/vstgui/uidescription/viewcreator/rowcolumnviewcreator.h
@@ -19,18 +19,18 @@ struct RowColumnViewCreator : ViewCreatorAdapter
 	IdStringPtr getBaseViewName () const override;
 	UTF8StringPtr getDisplayName () const override;
 	CView* create (const UIAttributes& attributes,
-	               const IUIDescription* description) const override;
+				   const IUIDescription* description) const override;
 	bool apply (CView* view, const UIAttributes& attributes,
-	            const IUIDescription* description) const override;
+				const IUIDescription* description) const override;
 	bool getAttributeNames (StringList& attributeNames) const override;
 	AttrType getAttributeType (const string& attributeName) const override;
 	bool getAttributeValue (CView* view, const string& attributeName, string& stringValue,
-	                        const IUIDescription* desc) const override;
+							const IUIDescription* desc) const override;
 	bool getPossibleListValues (const string& attributeName,
-	                            ConstStringPtrList& values) const override;
+								ConstStringPtrList& values) const override;
 
 private:
-	using LayoutStrings = std::array<string, 4>;
+	using LayoutStrings = std::array<string, 13>;
 	static LayoutStrings& layoutStrings ();
 };
 


### PR DESCRIPTION
Implementation of an Auto Layout like described on this website: https://medium.com/timeless/figma-updates-new-auto-layout-alignments-ec6cb134aea4

You can access the new layouts in the VSTGUI Live editor ```Row Column View Container: equal-size-layout``` (```equal-size-layout``` could be renamed as the new auto layout also allows different view sizes of children).

* auto layout is an extension of CRowColumnViews layout options
* new options ```top-left, top-center, top-right, middle-left, middle-center, middle-right, bottom-left, bottom-center, bottom-right``` integrate into the existing mechanism (the old ones are working as usual)
* ```Row Column View Container : spacing``` between views is maintained
* new unit tests for ```CRowColumView``` layout created
* existing ```RowColumViewCreator``` have been fixed (by adding the new options)

