### PR TITLE
Use [NSCursor pointingHandCursor] for kCursorHand

### DIFF
--- a/vstgui/lib/platform/mac/cocoa/nsviewframe.mm
+++ b/vstgui/lib/platform/mac/cocoa/nsviewframe.mm
@@ -1341,7 +1341,7 @@ bool NSViewFrame::setMouseCursor (CCursorType type)
 			break;
 		}
 		case kCursorNotAllowed: cur = [NSCursor performSelector:@selector(operationNotAllowedCursor)]; break;
-		case kCursorHand: cur = [NSCursor openHandCursor]; break;
+		case kCursorHand: cur = [NSCursor pointingHandCursor]; break;
 		case kCursorIBeam: cur = [NSCursor IBeamCursor]; break;
 		case kCursorCrosshair: cur = [NSCursor crosshairCursor]; break;
 		default: cur = [NSCursor arrowCursor]; break;


### PR DESCRIPTION
`[NSCursor pointingHandCursor]` is visually consistent with `IDC_HAND` on Windows.

![Screenshot 2025-04-16 110113](https://github.com/user-attachments/assets/600fc007-373d-47b4-83b2-f45f9c63a3c3)

https://developer.apple.com/documentation/appkit/nscursor

![Screenshot 2025-04-16 105900](https://github.com/user-attachments/assets/855fee1a-b883-4ea3-a288-be1cc9d2a66f)

https://learn.microsoft.com/en-us/windows/win32/menurc/about-cursors

Note that Windows has no built-in equivalent to `[NSCursor openHandCursor]`.