### PR TITLE
fix linux standalone on wayland

### DIFF
--- a/vstgui/standalone/source/platform/gdk/gdkapplication.cpp
+++ b/vstgui/standalone/source/platform/gdk/gdkapplication.cpp
@@ -81,6 +81,7 @@ private:
 //------------------------------------------------------------------------
 bool Application::init (int argc, char* argv[])
 {
+	gdk_set_allowed_backends ("x11");
 	const auto& appInfo = IApplication::instance ().getDelegate ().getInfo ();
 	app = Gtk::Application::create (argc, argv, appInfo.uri.data ());
 	Glib::set_application_name (appInfo.name.getString ());


### PR DESCRIPTION
This patch allows standalone apps to run on Wayland based Linux desktops.

Example apps were failing to display their GUIs and logging errors such as:

```
(standalone:6299): Gdk-CRITICAL **: 15:07:57.419: gdk_x11_window_get_xid: assertion 'GDK_IS_X11_WINDOW (window)' failed
```

VSTGUI::Standalone::Platform::GDK assumes that X11 is being used, so this patch forces GDK to use only its X11 backend.

https://docs.gtk.org/gdk3/func.set_allowed_backends.html