### PR TITLE
fix upside-down GUI in DP 9 / Live 9 on macOS 10.14

### DIFF
--- a/vstgui/lib/platform/mac/cocoa/nsviewframe.mm
+++ b/vstgui/lib/platform/mac/cocoa/nsviewframe.mm
@@ -958,14 +958,14 @@ NSViewFrame::NSViewFrame (IPlatformFrameCallback* frame, const CRect& size, NSVi
 	{
 		[nsView setWantsLayer:YES];
 		caLayer = [CALayer new];
-#if MAC_OS_X_VERSION_MIN_REQUIRED <= MAC_OS_X_VERSION_10_13
-		if (@available (macOS 10.14, *))
+#if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_15
+		if (@available (macOS 10.15, *))
 		{
 		}
 		else
 		{
-			// on macOS 10.13, the view is upside-down in Digital Performer if not flipping the
-			// geometry
+			// on macOS 10.13 and 10.14, the view is upside-down in Ableton Live 9 and Digital
+			// Performer 9 (both linked with SDK < 10.8) if not flipping the geometry
 			caLayer.geometryFlipped = ![nsView.layer contentsAreFlipped];
 		}
 #endif


### PR DESCRIPTION
`caLayer.geometryFlipped = ![nsView.layer contentsAreFlipped]` appears to also be required on 10.14 for applications linked to SDKs prior to 10.8.

https://forums.steinberg.net/t/guis-are-mirrored-vertically-mac/881197/30