### PR TITLE
fix redraw issues in Windows hosts with inconstant DPI awareness

### DIFF
--- a/vstgui/lib/platform/win32/win32dll.h
+++ b/vstgui/lib/platform/win32/win32dll.h
@@ -131,6 +131,34 @@ struct HiDPISupport : DllBase
 		return adjustWindowRectExForDpiProc (lpRect, dwStyle, bMenu, dwExStyle, dpi);
 	}
 
+	DPI_AWARENESS getAwarenessFromDpiAwarenessContext (DPI_AWARENESS_CONTEXT context)
+	{
+		if (getAwarenessFromDpiAwarenessContextFunc)
+			return getAwarenessFromDpiAwarenessContextFunc (context);
+		return DPI_AWARENESS_INVALID;
+	}
+
+	DPI_AWARENESS_CONTEXT getThreadDpiAwarenessContext ()
+	{
+		if (getThreadDpiAwarenessContextFunc)
+			return getThreadDpiAwarenessContextFunc ();
+		return NULL;
+	}
+
+	DPI_AWARENESS_CONTEXT getWindowDpiAwarenessContext (HWND hwnd)
+	{
+		if (getWindowDpiAwarenessContextFunc)
+			return getWindowDpiAwarenessContextFunc (hwnd);
+		return NULL;
+	}
+
+	DPI_AWARENESS_CONTEXT setThreadDpiAwarenessContext (DPI_AWARENESS_CONTEXT context)
+	{
+		if (setThreadDpiAwarenessContextFunc)
+			return setThreadDpiAwarenessContextFunc (context);
+		return NULL;
+	}
+
 private:
 	using GetDpiForWindowFunc = UINT (WINAPI*) (HWND hWnd);
 	using GetDpiForMonitorFunc = HRESULT (WINAPI*) (_In_ HMONITOR hmonitor,
@@ -142,12 +170,21 @@ private:
 	using SetProcessDpiAwarenessContextFunc = BOOL (WINAPI*) (_In_ DPI_AWARENESS_CONTEXT value);
 	using AdjustWindowRectExForDpiProc = BOOL (WINAPI*) (LPRECT, DWORD, BOOL, DWORD, UINT);
 
+	using GetAwarenessFromDpiAwarenessContextFunc = DPI_AWARENESS (WINAPI *) (_In_ DPI_AWARENESS_CONTEXT value);
+	using GetThreadDpiAwarenessContextFunc = DPI_AWARENESS_CONTEXT (WINAPI *) ();
+	using GetWindowDpiAwarenessContextFunc = DPI_AWARENESS_CONTEXT (WINAPI *) (_In_ HWND hwnd);
+	using SetThreadDpiAwarenessContextFunc = DPI_AWARENESS_CONTEXT (WINAPI *) (_In_ DPI_AWARENESS_CONTEXT value);
+
 	GetDpiForWindowFunc getDPIForWindowFunc {nullptr};
 	GetDpiForMonitorFunc getDpiForMonitorFunc {nullptr};
 	SetProcessDpiAwarnessFunc setProcessDpiAwarenessFunc {nullptr};
 	EnableNonClientDpiScalingFunc enableNonClientDpiScalingFunc {nullptr};
 	SetProcessDpiAwarenessContextFunc setProcessDpiAwarenessContextFunc {nullptr};
 	AdjustWindowRectExForDpiProc adjustWindowRectExForDpiProc {nullptr};
+	GetAwarenessFromDpiAwarenessContextFunc getAwarenessFromDpiAwarenessContextFunc {nullptr};
+	GetThreadDpiAwarenessContextFunc getThreadDpiAwarenessContextFunc {nullptr};
+	GetWindowDpiAwarenessContextFunc getWindowDpiAwarenessContextFunc {nullptr};
+	SetThreadDpiAwarenessContextFunc setThreadDpiAwarenessContextFunc {nullptr};
 
 	DllBase shCore {"Shcore.dll"};
 
@@ -162,6 +199,15 @@ private:
 		setProcessDpiAwarenessContextFunc = getProcAddress<SetProcessDpiAwarenessContextFunc> ("SetProcessDpiAwarenessContext");
 		adjustWindowRectExForDpiProc =
 			getProcAddress<AdjustWindowRectExForDpiProc> ("AdjustWindowRectExForDpi");
+		getAwarenessFromDpiAwarenessContextFunc =
+			getProcAddress<GetAwarenessFromDpiAwarenessContextFunc> (
+				"GetAwarenessFromDpiAwarenessContext");
+		getThreadDpiAwarenessContextFunc =
+			getProcAddress<GetThreadDpiAwarenessContextFunc> ("GetThreadDpiAwarenessContext");
+		getWindowDpiAwarenessContextFunc =
+			getProcAddress<GetWindowDpiAwarenessContextFunc> ("GetWindowDpiAwarenessContext");
+		setThreadDpiAwarenessContextFunc =
+			getProcAddress<SetThreadDpiAwarenessContextFunc> ("SetThreadDpiAwarenessContext");
 	}
 };
 

--- a/vstgui/lib/platform/win32/win32frame.cpp
+++ b/vstgui/lib/platform/win32/win32frame.cpp
@@ -51,6 +51,42 @@ static TCHAR gClassName[100];
 static bool bSwapped_mouse_buttons = false;
 
 //-----------------------------------------------------------------------------
+// Temporarily sets DPI awareness context of the thread to match the given HWND.
+//
+// This is needed to avoid redraw issues in some hosts (e.g. Ableton Live & Bitwig with "Auto-Scale
+// Plug-In Window" disabled) when calling InvalidRect from timers and drag & drop callbacks where
+// these hosts set the thread awareness to DPI_AWARENESS_UNAWARE.
+struct ThreadDPIAwarenessScope
+{
+	explicit ThreadDPIAwarenessScope (HWND hwnd) : oldContext (nullptr)
+	{
+		HiDPISupport& hidpi = HiDPISupport::instance ();
+
+		bool windowAware =
+			hidpi.getAwarenessFromDpiAwarenessContext (hidpi.getWindowDpiAwarenessContext (hwnd)) ==
+			DPI_AWARENESS_PER_MONITOR_AWARE;
+
+		bool threadAware =
+			hidpi.getAwarenessFromDpiAwarenessContext (hidpi.getThreadDpiAwarenessContext ()) ==
+			DPI_AWARENESS_PER_MONITOR_AWARE;
+
+		if (windowAware && !threadAware)
+			oldContext =
+				hidpi.setThreadDpiAwarenessContext (DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
+		else if (!windowAware && threadAware)
+			oldContext = hidpi.setThreadDpiAwarenessContext (DPI_AWARENESS_CONTEXT_UNAWARE);
+	}
+
+	~ThreadDPIAwarenessScope ()
+	{
+		if (oldContext != nullptr)
+			HiDPISupport::instance ().setThreadDpiAwarenessContext (oldContext);
+	}
+
+	DPI_AWARENESS_CONTEXT oldContext;
+};
+
+//-----------------------------------------------------------------------------
 static bool isParentLayered (HWND parent)
 {
 	WINDOWINFO info;
@@ -201,6 +237,8 @@ void Win32Frame::initTooltip ()
 {
 	if (tooltipWindow == nullptr && windowHandle)
 	{
+		ThreadDPIAwarenessScope scope (getHWND ());
+
 		TOOLINFO    ti;
 		// Create the ToolTip control.
 		HWND hwndTT = CreateWindow (TOOLTIPS_CLASS, TEXT(""),
@@ -312,6 +350,7 @@ bool Win32Frame::getSize (CRect& size) const
 //-----------------------------------------------------------------------------
 bool Win32Frame::getCurrentMousePosition (CPoint& mousePosition) const
 {
+	ThreadDPIAwarenessScope scope (getHWND ());
 	POINT _where;
 	GetCursorPos (&_where);
 	mousePosition (static_cast<CCoord> (_where.x), static_cast<CCoord> (_where.y));
@@ -412,6 +451,7 @@ bool Win32Frame::invalidRect (const CRect& rect)
 	if (!rect.isEmpty ())
 	{
 		RECT r = {(LONG)rect.left, (LONG)rect.top, (LONG)ceil (rect.right), (LONG)ceil (rect.bottom)};
+		ThreadDPIAwarenessScope scope (getHWND ());
 		InvalidateRect (windowHandle, &r, true);
 	}
 	return true;


### PR DESCRIPTION
This fixes an issue where, in certain DAWs and with HiDPI enabled, GUIs don't redraw correctly when InvalidRect is called outside of mouse or keyboard event handlers.

The logic is based on https://github.com/juce-framework/JUCE/blob/1b460fe0895635a2ab8ac5c00cb5575e33e5dc1e/modules/juce_gui_basics/native/juce_Windowing_windows.cpp#L583-L606