### PR TITLE
fix CALayer resizing under FL Studio

### DIFF
--- a/vstgui/lib/platform/mac/cocoa/nsviewframe.mm
+++ b/vstgui/lib/platform/mac/cocoa/nsviewframe.mm
@@ -1512,7 +1512,8 @@ bool NSViewFrame::getGlobalPosition (CPoint& pos) const
 bool NSViewFrame::setSize (const CRect& newSize)
 {
 	NSRect r = nsRectFromCRect (newSize);
-	if (NSEqualRects (r, [nsView frame]))
+	if (NSEqualRects (r, [nsView frame]) &&
+		(!caLayer || NSEqualRects ([caLayer frame], [nsView bounds])))
 		return true;
 
 	NSUInteger oldResizeMask = [nsView autoresizingMask];


### PR DESCRIPTION
This change fixes an issue where `caLayer.frame` was not always updated when hosted in FL Studio 2024 and earlier.

It appears that FL Studio directly sets the NSView's size before calling `IPlugView::onSize`, leading to `NSViewFrame::setSize` skipping the call to `[caLayer setFrame:]`