### PR TITLE
Fix array out of bounds crash

### DIFF
--- a/vstgui/lib/platform/linux/x11platform.cpp
+++ b/vstgui/lib/platform/linux/x11platform.cpp
@@ -118,7 +118,7 @@ struct RunLoop::Impl : IEventHandler
 	xkb_state* xkbUnprocessedState {nullptr};
 	xkb_keymap* xkbKeymap {nullptr};
 	WindowEventHandlerMap windowEventHandlerMap;
-	std::array<xcb_cursor_t, CCursorType::kCursorIBeam + 1> cursors {{XCB_CURSOR_NONE}};
+	std::array<xcb_cursor_t, CCursorType::kCursorMoveObject + 1> cursors {{XCB_CURSOR_NONE}};
 	KeyboardEvent lastUnprocessedKeyEvent;
 	uint32_t lastUtf32KeyEventChar {0};
 


### PR DESCRIPTION
Crash happens here: https://github.com/rehans/vstgui_wayland/blob/ac58ee567a78c9e6f1988db2913324bf01f66b88/vstgui/lib/platform/linux/x11platform.cpp#L484