### PR TITLE
Title (for kdialog) must be quoted because it can contain spaces

### DIFF
--- a/vstgui/lib/platform/linux/x11fileselector.cpp
+++ b/vstgui/lib/platform/linux/x11fileselector.cpp
@@ -89,6 +89,11 @@ private:
 		zenity
 	};
 
+	static auto quote (const UTF8String& str) -> UTF8String 
+	{ 
+		return "'" + str + "'"; 
+	}
+
 	void identifiyExDialogType ()
 	{
 		if (access (zenitypath, X_OK) != -1)
@@ -116,7 +121,7 @@ private:
 		if (!config.title.empty ())
 		{
 			args.push_back ("--title");
-			args.push_back (config.title.getString ());
+			args.push_back (quote (config.title).getString ());
 		}
 		if (!config.initialPath.empty ())
 			args.push_back (config.initialPath.getString ());


### PR DESCRIPTION
Using 
`kdialog --getopenfilename --title Hello World` 
only shows `Hello` in the title bar.

Quoting `Hello World` like this
`kdialog --getopenfilename --title 'Hello World'`
shows the full `Hello World` in the title bar.
 
I did not find a more modern way of quoting a string.