### PR TITLE
fix upside-down initial draw in FL Studio 2025

### DIFF
--- a/vstgui/lib/platform/mac/cocoa/nsviewframe.mm
+++ b/vstgui/lib/platform/mac/cocoa/nsviewframe.mm
@@ -1231,17 +1231,6 @@ NSViewFrame::NSViewFrame (IPlatformFrameCallback* frame, const CRect& size, NSVi
 	{
 		[nsView setWantsLayer:YES];
 		caLayer = [CALayer new];
-#if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_15
-		if (@available (macOS 10.15, *))
-		{
-		}
-		else
-		{
-			// on macOS 10.13 and 10.14, the view is upside-down in Ableton Live 9 and Digital
-			// Performer 9 (both linked with SDK < 10.8) if not flipping the geometry
-			caLayer.geometryFlipped = ![nsView.layer contentsAreFlipped];
-		}
-#endif
 		caLayer.delegate = static_cast<id<CALayerDelegate>> (nsView);
 		caLayer.frame = nsView.layer.bounds;
 		[caLayer setContentsScale:nsView.layer.contentsScale];
@@ -1396,6 +1385,9 @@ void NSViewFrame::draw (CGContextRef cgContext, CRect updateRect, double scaleFa
 //-----------------------------------------------------------------------------
 void NSViewFrame::drawLayer (CALayer* layer, CGContextRef ctx)
 {
+	if (![layer contentsAreFlipped])
+		CGContextConcatCTM (ctx, CGAffineTransformMake (1, 0, 0, -1, 0, layer.bounds.size.height));
+
 	auto clipBoundingBox = CGContextGetClipBoundingBox (ctx);
 	draw (ctx, rectFromNSRect (clipBoundingBox), layer.contentsScale);
 }
@@ -1644,7 +1636,7 @@ bool NSViewFrame::invalidRect (const CRect& rect)
 		return false;
 	NSRect r = nsRectFromCRect (rect);
 	if (caLayer)
-		[caLayer setNeedsDisplayInRect:r];
+		[caLayer setNeedsDisplayInRect:[nsView convertRectToLayer:r]];
 	else
 		[nsView setNeedsDisplayInRect:r];
 	if (useInvalidRects)


### PR DESCRIPTION
When using FL Studio 2025's "Detached" mode on macOS 14 and earlier, on Intel or Rosetta only, the initial draw appeared upside down from a user's point of view. Subsequent draws in response to mouse events or parameters changing had the correct orientation.

It seems that setting `geometryFlipped` according to the parent layer's `contentsAreFlipped` value does not guarantee correct drawing, because the value of `nsView.layer.contentsAreFlipped` could be changed by the host application or the OS. Looking for guidance from Apple, I found [WWDC 2012 Session 217 "Layer-Backed View"](https://archive.org/details/wwdc-2012-sessions/%5B2012%5D+%5BSession+217%5D+Layer-Backed+Views+-+AppKit+%2B+Core+Animation.mov) in which the presenter says at timestamp 40:39 :-

> You don't have to manage geometryFlipped, and you probably shouldn't change it

This patch implements what should be a more robust approach, which is to leave `geometryFlipped` alone and instead query `contentsAreFlipped` at draw time and adjust the CGContext's geometry if required.

I have verified that this works with DAWs that have been known to cause upside down drawing:
* FL Studio 2025 (Intel) on macOS 14 and earlier
* Ableton Live 9 on macOS 10.14 and earlier
* Digital Performer 9 on macOS 10.14 and earlier
* NI Maschine