### PR TITLE
Fix mousePosition for MouseUp events passed to IMouseObserver

### DIFF
--- a/vstgui/lib/cframe.cpp
+++ b/vstgui/lib/cframe.cpp
@@ -693,14 +693,17 @@ void CFrame::dispatchMouseMoveEvent (MouseMoveEvent& event)
 //------------------------------------------------------------------------
 void CFrame::dispatchMouseUpEvent (MouseUpEvent& event)
 {
+	auto originMousePosition = event.mousePosition;
 	auto transformedMousePosition = event.mousePosition;
 	getTransform ().inverse ().transform (transformedMousePosition);
 	
 	auto f = finally ([this] () { setMouseDownView (nullptr); });
 
+	event.mousePosition = transformedMousePosition;
 	callMouseObserverOtherMouseEvent (event);
 	if (event.consumed)
 		return;
+	event.mousePosition = originMousePosition;
 
 	if (auto modalView = shared (getModalView ()))
 	{


### PR DESCRIPTION
This fix applies the same transformation logic to `dispatchMouseUpEvent` that was already being done in `dispatchMouseDownEvent` and `dispatchMouseMoveEvent`.

Without this, the mouse positions passed to `IMouseObserver` for `MouseUp` events did not match the positions for mouse down and move events.