### PR TITLE
fix CFrame::getCurrentMouseLocation

### DIFF
--- a/vstgui/lib/cframe.cpp
+++ b/vstgui/lib/cframe.cpp
@@ -1112,7 +1112,6 @@ bool CFrame::getCurrentMouseLocation (CPoint &where) const
 	{
 		if (pImpl->platformFrame->getCurrentMousePosition (where))
 		{
-			getTransform().transform (where);
 			return true;
 		}
 	}

--- a/vstgui/lib/platform/common/genericoptionmenu.cpp
+++ b/vstgui/lib/platform/common/genericoptionmenu.cpp
@@ -718,7 +718,8 @@ void GenericOptionMenu::popup (COptionMenu* optionMenu, const Callback& callback
 		self->removeModalView ({menu, index});
 	};
 
-	auto viewRect = optionMenu->translateToGlobal (optionMenu->getViewSize (), true);
+	auto viewRect = optionMenu->translateToGlobal (optionMenu->getViewSize ());
+	viewRect.offset (-optionMenu->getFrame ()->getViewSize ().getTopLeft ());
 	auto where = viewRect.getCenter ();
 
 	GenericOptionMenuDetail::setupGenericOptionMenu (clickCallback, impl->container, optionMenu,


### PR DESCRIPTION
The use of `getTransform ().transform (where)` was definitely incorrect; when using a scaled UI it would return mouse locations outside of the frame's rect as returned by `getSize()` or `getViewSize()`.

Seemingly broken by commit 485827ff89af7664f192940f56b619fa46f5c91e

Removing the transform fixes an issue where `VSTGUIEditor::onWheel` would send events to the wrong view.

There could also be an argument for applying the inverse transform, I'm not sure what fits best into the vstgui design. But given that `frame->getSize` / `getViewSize` returns untransformed coordinates, one would expect the same of `getCurrentMouseLocation`.

The use of `getCurrentMouseLocation` in `GenericOptionMenu::popup` looks suspicious to me; but I have not been able to debug it to determine if it needs updating.