### PR TITLE
Set XEMBED_MAPPED

### DIFF
--- a/vstgui/lib/platform/linux/x11utils.h
+++ b/vstgui/lib/platform/linux/x11utils.h
@@ -58,7 +58,7 @@ private:
 struct XEmbedInfo
 {
 	uint32_t version{1};
-	uint32_t flags{0};
+	uint32_t flags{1};
 };
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
Fixes https://github.com/steinbergmedia/vstgui/issues/372

The missing flag caused VSTGUI based UIs to not be displayed in hosts that use some recent versions of JUCE.