### PR TITLE
Revert "Title (for kdialog) must be quoted because it can contain spa…

### DIFF
--- a/vstgui/lib/platform/linux/x11fileselector.cpp
+++ b/vstgui/lib/platform/linux/x11fileselector.cpp
@@ -89,11 +89,6 @@ private:
 		zenity
 	};
 
-	static auto quote (const UTF8String& str) -> UTF8String 
-	{ 
-		return "'" + str + "'"; 
-	}
-
 	void identifiyExDialogType ()
 	{
 		if (access (zenitypath, X_OK) != -1)
@@ -121,7 +116,7 @@ private:
 		if (!config.title.empty ())
 		{
 			args.push_back ("--title");
-			args.push_back (quote (config.title).getString ());
+			args.push_back (config.title.getString ());
 		}
 		if (!config.initialPath.empty ())
 			args.push_back (config.initialPath.getString ());


### PR DESCRIPTION
…ces"

This reverts commit 851f93a52190f442a924a830e86b30b0b9024f7b.

As @nickdowell pointed out correctly here: https://github.com/steinbergmedia/vstgui/commit/851f93a52190f442a924a830e86b30b0b9024f7b#commitcomment-184340200