### PR TITLE
Fixed Linux rendering of drawEllipse() & drawArc()

### DIFF
--- a/vstgui/lib/platform/linux/cairographicscontext.cpp
+++ b/vstgui/lib/platform/linux/cairographicscontext.cpp
@@ -468,9 +468,12 @@ bool CairoGraphicsDeviceContext::drawArc (CRect rect, double startAngle1, double
 {
 	impl->doInContext ([&] () {
 		CPoint center = rect.getCenter ();
+		cairo_matrix_t save_matrix;
+		cairo_get_matrix( impl->context, & save_matrix );
 		cairo_translate (impl->context, center.x, center.y);
-		cairo_scale (impl->context, 2.0 / rect.getWidth (), 2.0 / rect.getHeight ());
+		cairo_scale (impl->context, 0.5 * rect.getWidth(), 0.5 * rect.getHeight());
 		cairo_arc (impl->context, 0, 0, 1, startAngle1, endAngle2);
+		cairo_set_matrix( impl->context, & save_matrix );
 		impl->draw (drawStyle);
 	});
 	return true;
@@ -479,14 +482,17 @@ bool CairoGraphicsDeviceContext::drawArc (CRect rect, double startAngle1, double
 //------------------------------------------------------------------------
 bool CairoGraphicsDeviceContext::drawEllipse (CRect rect, PlatformGraphicsDrawStyle drawStyle) const
 {
-	impl->doInContext ([&] () {
-		CPoint center = rect.getCenter ();
-		cairo_translate (impl->context, center.x, center.y);
-		cairo_scale (impl->context, 2.0 / rect.getWidth (), 2.0 / rect.getHeight ());
-		cairo_arc (impl->context, 0, 0, 1, 0, 2 * M_PI);
-		impl->draw (drawStyle);
-	});
-	return true;
+    impl->doInContext ([&] () {
+        CPoint center = rect.getCenter ();
+        cairo_matrix_t save_matrix;
+        cairo_get_matrix( impl->context, & save_matrix );
+        cairo_translate (impl->context, center.x, center.y);
+        cairo_scale( impl->context, 0.5 * rect.getWidth(), 0.5 * rect.getHeight() );
+        cairo_arc (impl->context, 0, 0, 1, 0, 2 * M_PI);
+        cairo_set_matrix( impl->context, & save_matrix );
+        impl->draw (drawStyle);
+    });
+    return true;
 }
 
 //------------------------------------------------------------------------

--- a/vstgui/lib/platform/linux/cairographicscontext.cpp
+++ b/vstgui/lib/platform/linux/cairographicscontext.cpp
@@ -468,12 +468,11 @@ bool CairoGraphicsDeviceContext::drawArc (CRect rect, double startAngle1, double
 {
 	impl->doInContext ([&] () {
 		CPoint center = rect.getCenter ();
-		cairo_matrix_t save_matrix;
-		cairo_get_matrix( impl->context, & save_matrix );
+		cairo_save (impl->context);
 		cairo_translate (impl->context, center.x, center.y);
 		cairo_scale (impl->context, 0.5 * rect.getWidth(), 0.5 * rect.getHeight());
 		cairo_arc (impl->context, 0, 0, 1, startAngle1, endAngle2);
-		cairo_set_matrix( impl->context, & save_matrix );
+		cairo_restore (impl->context);
 		impl->draw (drawStyle);
 	});
 	return true;
@@ -482,17 +481,16 @@ bool CairoGraphicsDeviceContext::drawArc (CRect rect, double startAngle1, double
 //------------------------------------------------------------------------
 bool CairoGraphicsDeviceContext::drawEllipse (CRect rect, PlatformGraphicsDrawStyle drawStyle) const
 {
-    impl->doInContext ([&] () {
-        CPoint center = rect.getCenter ();
-        cairo_matrix_t save_matrix;
-        cairo_get_matrix( impl->context, & save_matrix );
-        cairo_translate (impl->context, center.x, center.y);
-        cairo_scale( impl->context, 0.5 * rect.getWidth(), 0.5 * rect.getHeight() );
-        cairo_arc (impl->context, 0, 0, 1, 0, 2 * M_PI);
-        cairo_set_matrix( impl->context, & save_matrix );
-        impl->draw (drawStyle);
-    });
-    return true;
+	impl->doInContext ([&] () {
+		CPoint center = rect.getCenter ();
+		cairo_save (impl->context);
+		cairo_translate (impl->context, center.x, center.y);
+		cairo_scale (impl->context, 0.5 * rect.getWidth(), 0.5 * rect.getHeight() );
+		cairo_arc (impl->context, 0, 0, 1, 0, 2 * M_PI);
+		cairo_restore (impl->context);
+		impl->draw (drawStyle);
+	});
+	return true;
 }
 
 //------------------------------------------------------------------------

--- a/vstgui/lib/platform/linux/cairographicscontext.cpp
+++ b/vstgui/lib/platform/linux/cairographicscontext.cpp
@@ -470,7 +470,7 @@ bool CairoGraphicsDeviceContext::drawArc (CRect rect, double startAngle1, double
 		CPoint center = rect.getCenter ();
 		cairo_save (impl->context);
 		cairo_translate (impl->context, center.x, center.y);
-		cairo_scale (impl->context, 0.5 * rect.getWidth(), 0.5 * rect.getHeight());
+		cairo_scale (impl->context, 0.5 * rect.getWidth (), 0.5 * rect.getHeight ());
 		cairo_arc (impl->context, 0, 0, 1, startAngle1, endAngle2);
 		cairo_restore (impl->context);
 		impl->draw (drawStyle);
@@ -485,7 +485,7 @@ bool CairoGraphicsDeviceContext::drawEllipse (CRect rect, PlatformGraphicsDrawSt
 		CPoint center = rect.getCenter ();
 		cairo_save (impl->context);
 		cairo_translate (impl->context, center.x, center.y);
-		cairo_scale (impl->context, 0.5 * rect.getWidth(), 0.5 * rect.getHeight() );
+		cairo_scale (impl->context, 0.5 * rect.getWidth (), 0.5 * rect.getHeight ());
 		cairo_arc (impl->context, 0, 0, 1, 0, 2 * M_PI);
 		cairo_restore (impl->context);
 		impl->draw (drawStyle);


### PR DESCRIPTION
Provides fix for broken rendering issue on Linux, https://github.com/steinbergmedia/vstgui/issues/333, where `drawArc()` and `drawEllipse()` in CairoGraphicsContext had incorrect scaling.

This now takes that into consideration when using cairo_arc, as suggested in the Cairo cookbook documentation here: https://cairo.freedesktop.org/cookbook/ellipses/

> Credit to @Distb for posting the issue and fix for `drawEllipse()`, saved me a lot of headache figuring out why Linux wasn't consistent with other platforms ❤️ 

